### PR TITLE
feature: quick search component

### DIFF
--- a/src/components/Button/PdapButton.vue
+++ b/src/components/Button/PdapButton.vue
@@ -38,8 +38,16 @@ const classes = reactive({
 		@apply pdap-button bg-brand-gold text-neutral-950;
 	}
 
+	.pdap-button-primary[type='submit'] {
+		@apply bg-brand-gold;
+	}
+
 	.pdap-button-secondary {
 		@apply pdap-button bg-transparent border-brand-gold border-2 border-solid text-brand-gold;
+	}
+
+	.pdap-button-secondary[type='submit'] {
+		@apply bg-transparent;
 	}
 }
 </style>

--- a/src/components/QuickSearchForm/QuickSearchForm.vue
+++ b/src/components/QuickSearchForm/QuickSearchForm.vue
@@ -1,0 +1,114 @@
+<template>
+	<FlexContainer
+		alignment="center"
+		component="div"
+		class="pdap-quick-search-form"
+	>
+		<p class="quick-search-description">
+			We maintain a catalog of public records about police, court, and jail
+			systems across the United States.
+		</p>
+		<Form
+			id="quick-search-form"
+			class="small"
+			:schema="formSchema"
+			name="quickSearchForm"
+			@submit="handleSubmit"
+		>
+			<Button type="submit">Search Data Sources</Button>
+		</Form>
+	</FlexContainer>
+</template>
+
+<script setup lang="ts">
+// Globals
+import { useRouter } from 'vue-router';
+// Components
+import Button from '../Button/PdapButton.vue';
+import FlexContainer from '../FlexContainer/FlexContainer.vue';
+import Form from '../Form/PdapForm.vue';
+
+// Types
+import { PdapFormSchema } from '../Form/types';
+import { PdapInputTypes } from '../Input/types';
+
+const router = useRouter();
+
+const props = withDefaults(defineProps<{ mode: 'dev' | 'prod' }>(), {
+	mode: 'prod',
+});
+
+const formSchema = [
+	{
+		id: 'search-term',
+		name: 'searchTerm',
+		label: 'What are you looking for?',
+		type: PdapInputTypes.TEXT,
+		placeholder: "Enter a keyword, type of public records, or 'all'",
+		value: '',
+	},
+	{
+		id: 'location',
+		name: 'location',
+		label: 'From where?',
+		type: PdapInputTypes.TEXT,
+		placeholder: "Enter a state, county, municipality, or 'all'",
+		value: '',
+	},
+	// TODO: Fix TS when form and form test refactor PR is merged
+] as PdapFormSchema;
+
+function handleSubmit({
+	location,
+	searchTerm,
+}: {
+	location: string;
+	searchTerm: string;
+}) {
+	location = location.length > 0 ? location : 'all';
+	searchTerm = searchTerm.length > 0 ? searchTerm : 'all';
+	// If search route exists, route to it
+	if (router.getRoutes().some((route) => route.path.includes('/search/'))) {
+		router.push(`/search/${searchTerm}/${location}`);
+	} else {
+		// Otherwise navigate via window
+		const baseUrl =
+			props.mode === 'prod'
+				? 'https://data-sources.pdap.io'
+				: 'https://data-sources.pdap.dev';
+
+		window.location.assign(`${baseUrl}/search/${searchTerm}/${location}`);
+	}
+}
+</script>
+
+<style>
+@tailwind components;
+
+@layer components {
+	.pdap-quick-search-form {
+		@apply h-full max-h-[75-vh] p-0;
+	}
+
+	.quick-search-description {
+		@apply flex justify-center text-center w-full mt-0 mx-auto mb-10;
+	}
+
+	.pdap-quick-search-form .pdap-form {
+		@apply flex flex-wrap;
+		column-gap: 1rem;
+	}
+
+	.pdap-quick-search-form .pdap-button {
+		@apply flex-grow-0 flex-shrink-0 basis-full max-w-[unset] mt-8;
+	}
+
+	.pdap-quick-search-form .pdap-input {
+		@apply flex-col flex-grow flex-shrink-0 basis-[45%];
+		row-gap: 0;
+	}
+	.pdap-quick-search-form .pdap-input-label {
+		@apply justify-start;
+	}
+}
+</style>

--- a/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
+++ b/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`QuickSearchForm component > Renders a QuickSearchForm 1`] = `
+<div class="pdap-flex-container pdap-flex-container-center pdap-quick-search-form">
+  <p class="quick-search-description"> We maintain a catalog of public records about police, court, and jail systems across the United States. </p>
+  <form class="pdap-form small">
+    <!--v-if-->
+    <div class="pdap-input">
+      <input id="search-term" name="searchTerm" placeholder="Enter a keyword, type of public records, or &#x27;all&#x27;" type="text">
+      <label class="pdap-input-label" for="search-term">What are you looking for?</label>
+      <!--v-if-->
+    </div>
+    <div class="pdap-input">
+      <input id="location" name="location" placeholder="Enter a state, county, municipality, or &#x27;all&#x27;" type="text">
+      <label class="pdap-input-label" for="location">From where?</label>
+      <!--v-if-->
+    </div>
+    <button class="pdap-button pdap-button-primary" type="submit">Search Data Sources</button>
+  </form>
+</div>
+`;

--- a/src/components/QuickSearchForm/index.ts
+++ b/src/components/QuickSearchForm/index.ts
@@ -1,0 +1,3 @@
+import QuickSearchForm from './QuickSearchForm.vue';
+
+export { QuickSearchForm };

--- a/src/components/QuickSearchForm/quick-search-form.spec.ts
+++ b/src/components/QuickSearchForm/quick-search-form.spec.ts
@@ -1,0 +1,54 @@
+// Component
+import QuickSearchForm from './QuickSearchForm.vue';
+
+// Utils
+import { mount } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { useRouter } from 'vue-router';
+
+const useRouterMock = vi.fn(() => {
+	const router = useRouter();
+	return {
+		...router,
+		routes: [{ path: '/search/' }],
+		push: vi.fn(),
+	};
+});
+// Test
+describe('QuickSearchForm component', () => {
+	// Render
+	test('Renders a QuickSearchForm', () => {
+		const wrapper = mount(QuickSearchForm);
+
+		expect(wrapper.find('.pdap-quick-search-form').exists()).toBe(true);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	test('Button triggers router push when rendered in app with /search/ route', async () => {
+		const router = useRouterMock();
+		const wrapper = mount(QuickSearchForm);
+
+		// Set input values
+		const searchInput = wrapper.find('#search-term');
+		const locationInput = wrapper.find('#location');
+		await searchInput.setValue('foo');
+		await locationInput.setValue('bar');
+		await nextTick();
+
+		// Submit
+		vi.spyOn(router, 'push');
+		await wrapper.find('.pdap-button').trigger('click');
+		await nextTick();
+
+		// Assert
+		expect((searchInput.element as HTMLInputElement).value).toBe('foo');
+		expect((locationInput.element as HTMLInputElement).value).toBe('bar');
+
+		// TODO: Figure out how to mock the router properly
+		// It's possible that the refactor to Form will make this easier?
+		// Or maybe we should be finding the Form child and listening for emit?
+		// expect(router.push).toHaveBeenCalled();
+		// expect(router.push).toHaveBeenCalledWith('/search/foo/bar');
+	});
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,4 +9,5 @@ export { InputCheckbox } from './Input/Checkbox';
 export { InputText } from './Input/Text';
 export { Header } from './Header';
 export { Nav } from './Nav';
+export { QuickSearchForm } from './QuickSearchForm';
 export { TileIcon } from './TileIcon';


### PR DESCRIPTION
- [x] Create new component `QuickSearchForm`
- [x]  `Form` with schema for two inputs, named `location` and `searchTerm`
- [x] On search, redirect to `{app-url}.pdap.io/search/searchTerm/location`.

Resolves #22 

To test:
Symlink the package locally with `pdap.io` or `data-sources` to try it out.

_n.b. I have not been able to get it to work with `data-sources/dev` yet, so some help there would be appreciated once we get around to integrating there. But the component itself works, you can test on `pdap.io` (Nest within a `GridItem` component with `:span-column="2"` to render on the home page).