### PR TITLE
fix: quick search form validation

### DIFF
--- a/src/components/Footer/footer.spec.ts
+++ b/src/components/Footer/footer.spec.ts
@@ -2,14 +2,20 @@
 import PdapFooter from './PdapFooter.vue';
 
 // Utils
-import { mount } from '@vue/test-utils';
+import { RouterLinkStub, mount } from '@vue/test-utils';
 import { describe, expect, test } from 'vitest';
+
+const base = {
+	stubs: {
+		RouterLink: RouterLinkStub,
+	},
+};
 
 // Test
 describe('Footer component', () => {
 	// Render
 	test('Renders a footer', () => {
-		const wrapper = mount(PdapFooter);
+		const wrapper = mount(PdapFooter, base);
 
 		expect(wrapper.find('.pdap-footer').exists()).toBe(true);
 		expect(wrapper.find('.pdap-footer-social-links').exists()).toBe(true);
@@ -20,7 +26,7 @@ describe('Footer component', () => {
 	// Props
 	// Props - logo src
 	test('Renders footer with default logo src', () => {
-		const wrapper = mount(PdapFooter);
+		const wrapper = mount(PdapFooter, base);
 		expect(wrapper.props().logoImageSrc).toBe(
 			'node_modules/pdap-design-system/dist/images/acronym.svg'
 		);
@@ -28,6 +34,7 @@ describe('Footer component', () => {
 
 	test('Renders footer with custom logo src', () => {
 		const wrapper = mount(PdapFooter, {
+			...base,
 			props: { logoImageSrc: 'test' },
 		});
 		expect(wrapper.props().logoImageSrc).toBe('test');
@@ -35,12 +42,13 @@ describe('Footer component', () => {
 
 	// Props - anchor path
 	test('Renders footer with default logo anchor path', () => {
-		const wrapper = mount(PdapFooter);
+		const wrapper = mount(PdapFooter, base);
 		expect(wrapper.props().logoImageAnchorPath).toBe('/');
 	});
 
 	test('Renders footer with custom logo anchor path', () => {
 		const wrapper = mount(PdapFooter, {
+			...base,
 			props: { logoImageAnchorPath: '/test' },
 		});
 		expect(wrapper.props().logoImageAnchorPath).toBe('/test');
@@ -48,6 +56,7 @@ describe('Footer component', () => {
 
 	test('Renders footer with custom logo anchor href', () => {
 		const wrapper = mount(PdapFooter, {
+			...base,
 			props: { logoImageAnchorPath: 'www.test.com' },
 		});
 		expect(wrapper.props().logoImageAnchorPath).toBe('www.test.com');

--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -1,7 +1,7 @@
 <template>
 	<form class="pdap-form" @submit.prevent="submit($event)">
 		<div
-			v-if="typeof errorMessage === 'string' && errorMessage.length > 0"
+			v-if="typeof errorMessage === 'string'"
 			class="pdap-form-error-message"
 		>
 			{{ errorMessage }}
@@ -110,6 +110,7 @@ watchEffect(() => {
 // Effect - Debug logger
 watchEffect(() => {
 	console.debug(`PdapForm ${props.name}\n`, {
+		errorMessage: errorMessage.value,
 		props,
 		values,
 		vuelidate: {

--- a/src/components/Form/form.spec.ts
+++ b/src/components/Form/form.spec.ts
@@ -80,10 +80,7 @@ vi.mock('@vuelidate/core', async () => {
 	};
 });
 
-const handlers = {
-	submit: (values: Record<string, string>) => values,
-};
-
+const submit = vi.fn((values: Record<string, string>) => values);
 const base = {
 	global: {
 		mocks: {
@@ -101,7 +98,7 @@ const base = {
 		name: 'test',
 	},
 	attrs: {
-		submit: handlers.submit,
+		onSubmit: submit,
 	},
 	slots: {
 		default: '<button type="submit">Submit</button>',
@@ -114,6 +111,8 @@ describe('Form component', () => {
 
 		expect(wrapper.find('.pdap-form').exists()).toBe(true);
 		expect(wrapper.find('.pdap-form-error-message').exists()).toBe(false);
+		expect(wrapper.find('#test-1').exists()).toBe(true);
+		expect(wrapper.find('#test-1').attributes('validators')).toBe(undefined);
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
@@ -193,12 +192,15 @@ describe('Form component', () => {
 
 		await wrapper.find('form').trigger('submit');
 		await nextTick();
+		await wrapper.vm.$forceUpdate();
 
-		// TODO: This technically gets coverage, but doesn't assert against anything...
-		// ....How to fix testing of emitted events and submit handler? None of this is working as
-		// ....expected per Vue Test Utils docs: https://test-utils.vuejs.org/guide/essentials/forms
-		// expect(wrapper.emitted('submit')?.[0][0]).toBe('foo');
-		// expect(submitSpy).toHaveBeenCalled();
+		expect(wrapper.emitted('submit')?.[0][0]).toStrictEqual({
+			checkboxDefaultChecked: 'true',
+			checkboxDefaultUnchecked: 'false',
+			testOne: 'foo',
+			testTwo: 'bar',
+		});
+		expect(submit).toHaveBeenCalled();
 	});
 
 	test('Form validation with incorrect values and clears form error state', async () => {

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -46,7 +46,6 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-	/* c8 ignore next 1 */
 	window.removeEventListener('resize', getHeight);
 });
 

--- a/src/components/Header/header.spec.ts
+++ b/src/components/Header/header.spec.ts
@@ -4,7 +4,7 @@
 import PdapHeader from './PdapHeader.vue';
 
 // Utils
-import { mount } from '@vue/test-utils';
+import { RouterLinkStub, mount } from '@vue/test-utils';
 import { describe, expect, test, vi } from 'vitest';
 
 // Mocks
@@ -30,6 +30,9 @@ const base = {
 				console.warn(msg, instance, trace);
 			},
 		},
+	},
+	stubs: {
+		RouterLink: RouterLinkStub,
 	},
 };
 
@@ -84,5 +87,11 @@ describe('Header component', () => {
 			props: { logoImageAnchorPath: 'www.test.com' },
 		});
 		expect(wrapper.props().logoImageAnchorPath).toBe('www.test.com');
+	});
+
+	test('Header is unmounted from the DOM', async () => {
+		const wrapper = mount(PdapHeader, base);
+
+		wrapper.unmount();
 	});
 });

--- a/src/components/Nav/PdapNav.vue
+++ b/src/components/Nav/PdapNav.vue
@@ -88,7 +88,6 @@ onBeforeMount(() => {
 });
 
 onBeforeUnmount(() => {
-	/* c8 ignore next 1 */
 	window.removeEventListener('resize', setIsMobile);
 });
 

--- a/src/components/Nav/nav.spec.ts
+++ b/src/components/Nav/nav.spec.ts
@@ -4,12 +4,13 @@
 import PdapNav from './PdapNav.vue';
 
 // Utils
-import { mount } from '@vue/test-utils';
+import { RouterLinkStub, mount } from '@vue/test-utils';
 import { describe, expect, test, vi } from 'vitest';
 import { nextTick } from 'vue';
 
 // Mocks
 vi.mock('vue-router');
+
 const base = {
 	global: {
 		mocks: {
@@ -38,6 +39,9 @@ const base = {
 				console.warn(msg, instance, trace);
 			},
 		},
+	},
+	stubs: {
+		RouterLink: RouterLinkStub,
 	},
 };
 
@@ -88,5 +92,11 @@ describe('Nav component', () => {
 		button.trigger('click');
 		await nextTick();
 		expect(nav.attributes('aria-expanded')).toBe('false');
+	});
+
+	test('Nav is unmounted from the DOM', async () => {
+		const wrapper = mount(PdapNav, base);
+
+		wrapper.unmount();
 	});
 });

--- a/src/components/QuickSearchForm/QuickSearchForm.vue
+++ b/src/components/QuickSearchForm/QuickSearchForm.vue
@@ -7,6 +7,7 @@
 		<Form
 			id="quick-search-form"
 			class="small"
+			:error="error"
 			:schema="formSchema"
 			name="quickSearchForm"
 			@submit="handleSubmit"
@@ -26,6 +27,7 @@ import Form from '../Form/PdapForm.vue';
 
 // Types
 import { PdapInputTypes } from '../Input/types';
+import { ref } from 'vue';
 
 const router = useRouter();
 
@@ -52,10 +54,22 @@ const formSchema = [
 	},
 ];
 
+const error = ref<string | undefined>(undefined);
+
 function handleSubmit(values: { location: string; searchTerm: string }) {
+	/**  Extra validation - backend expects 1 form value to be filled in.
+	 *   The other input will be set to 'all'
+	 */
+	if (Object.values(values).every((val) => !val)) {
+		error.value = 'Either a search term or a location is required.';
+		return;
+	}
+
 	let { location, searchTerm } = values;
+
 	location = location && location.length > 0 ? location : 'all';
 	searchTerm = searchTerm && searchTerm.length > 0 ? searchTerm : 'all';
+
 	// If search route exists, route to it
 	if (router.getRoutes().some((route) => route.path.includes('/search/'))) {
 		router.push(`/search/${searchTerm}/${location}`);

--- a/src/components/QuickSearchForm/quick-search-form.spec.ts
+++ b/src/components/QuickSearchForm/quick-search-form.spec.ts
@@ -44,7 +44,7 @@ describe('QuickSearchForm component', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
-	test('Button triggers router push when rendered in app with /search/ route', async () => {
+	test('Form triggers router push when rendered in app with /search/ route', async () => {
 		getRoutes.mockReturnValueOnce([{ path: '/search/:foo/:bar' }]);
 
 		const wrapper = mount(QuickSearchForm, base);
@@ -63,15 +63,15 @@ describe('QuickSearchForm component', () => {
 		// Submit
 		await wrapper.find('form').trigger('submit.prevent');
 		await nextTick();
+		await wrapper.vm.$forceUpdate();
 
 		// Assert submit event
 		expect(wrapper.emitted()).toHaveProperty('submit');
 		expect(wrapper.emitted('submit')?.length).toBe(1);
-		// TODO: how to test router push called via form submit event. Not working anywhere.
-		// expect(push).toHaveBeenCalledWith('/search/foo/bar');
+		expect(push).toHaveBeenCalledWith('/search/foo/bar');
 	});
 
-	test('Button triggers window navigation when rendered in app without /search/ route — prod mode', async () => {
+	test('Form triggers window navigation when rendered in app without /search/ route — prod mode', async () => {
 		getRoutes.mockReturnValueOnce([
 			{ path: '/' },
 			{ path: '/foo' },
@@ -90,17 +90,18 @@ describe('QuickSearchForm component', () => {
 		// Submit
 		await wrapper.find('form').trigger('submit');
 		await nextTick();
+		await wrapper.vm.$forceUpdate();
 
 		// Assert submit event
 		expect(wrapper.emitted()).toHaveProperty('submit');
 
 		// TODO: how to test window.assign called via form submit event. Not working anywhere.
-		// expect(assign).toHaveBeenCalledWith(
-		// 	'https://data-sources.pdap.io/search/foo/bar'
-		// );
+		expect(assign).toHaveBeenCalledWith(
+			'https://data-sources.pdap.io/search/foo/bar'
+		);
 	});
 
-	test('Button triggers window navigation when rendered in app without /search/ route — dev mode', async () => {
+	test('Form triggers window navigation when rendered in app without /search/ route — dev mode', async () => {
 		getRoutes.mockReturnValueOnce([
 			{ path: '/' },
 			{ path: '/foo' },
@@ -124,13 +125,28 @@ describe('QuickSearchForm component', () => {
 		// Submit
 		await wrapper.find('form').trigger('submit');
 		await nextTick();
+		await wrapper.vm.$forceUpdate();
 
 		// Assert submit event
 		expect(wrapper.emitted()).toHaveProperty('submit');
 
-		// TODO: how to test window.assign called via form submit event. Not working anywhere.
-		// expect(assign).toHaveBeenCalledWith(
-		// 	'https://data-sources.pdap.dev/search/foo/bar'
-		// );
+		expect(assign).toHaveBeenCalledWith(
+			'https://data-sources.pdap.dev/search/foo/bar'
+		);
+	});
+
+	test('Form errors when submitted with both inputs blank', async () => {
+		const wrapper = mount(QuickSearchForm, base);
+
+		// Submit
+		await wrapper.find('form').trigger('submit.prevent');
+		await nextTick();
+		await wrapper.vm.$forceUpdate();
+
+		// Assert error message
+		expect(wrapper.find('.pdap-form-error-message').exists()).toBe(true);
+		expect(wrapper.get('.pdap-form-error-message').text()).toBe(
+			'Either a search term or a location is required.'
+		);
 	});
 });

--- a/src/utils/vuelidate.test.ts
+++ b/src/utils/vuelidate.test.ts
@@ -1,0 +1,110 @@
+// import * as validators from '@vuelidate/validators';
+import { describe, expect, test } from 'vitest';
+import {
+	createRule,
+	isLengthRule,
+	isPdapVuelidateValidator,
+	makeLengthRule,
+	makeLengthRuleWithCustomMessage,
+	makeRequiredRule,
+	makeRequiredRuleWithCustomMessage,
+} from './vuelidate';
+import { ValidationRuleWithParams } from '@vuelidate/core';
+
+// Utils
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateMax(max: any, length: any) {
+	expect(max).toHaveProperty('maxLength');
+	expect(max.maxLength.$params).toStrictEqual({
+		max: length,
+		type: 'maxLength',
+	});
+}
+
+describe('Vuelidate utils', () => {
+	test('isPdapVuelidateValidator', () => {
+		expect(isPdapVuelidateValidator('maxLength')).toBe(true);
+		expect(isPdapVuelidateValidator('minLength')).toBe(true);
+		expect(isPdapVuelidateValidator('required')).toBe(true);
+		expect(isPdapVuelidateValidator('foo')).toBe(false);
+	});
+
+	test('isLengthRule', () => {
+		expect(isLengthRule('maxLength')).toBe(true);
+		expect(isLengthRule('minLength')).toBe(true);
+		expect(isLengthRule('required')).toBe(false);
+		expect(isLengthRule('foo')).toBe(false);
+	});
+
+	test('makeLengthRule - max', () => {
+		const max = makeLengthRule('maxLength', 1);
+		validateMax(max, 1);
+	});
+
+	test('makeLengthRuleWithCustomMessage - max', () => {
+		const maxWithMessage = makeLengthRuleWithCustomMessage(
+			'maxLength',
+			1,
+			'error message'
+		);
+		expect(maxWithMessage).toHaveProperty('maxLength');
+		expect(maxWithMessage.maxLength.$params).toStrictEqual({
+			max: 1,
+			type: 'maxLength',
+		});
+		expect(maxWithMessage.maxLength.$message).toBe('error message');
+	});
+
+	test('makeRequiredRule', () => {
+		const required = makeRequiredRule();
+		expect(required).toHaveProperty('required');
+		expect(
+			(required['required'] as unknown as ValidationRuleWithParams).$params
+		).toStrictEqual({
+			type: 'required',
+		});
+	});
+
+	test('makeRequiredRuleWithCustomMessage', () => {
+		const requiredWithMessage =
+			makeRequiredRuleWithCustomMessage('error message');
+		expect(requiredWithMessage).toHaveProperty('required');
+		expect(
+			(requiredWithMessage['required'] as unknown as ValidationRuleWithParams)
+				.$params
+		).toStrictEqual({
+			type: 'required',
+		});
+		expect(requiredWithMessage['required'].$message).toBe('error message');
+	});
+
+	describe('createRule', () => {
+		test('creates length rules', () => {
+			const max = createRule('maxLength', { value: 3 });
+			validateMax(max, 3);
+			const maxWithMessage = createRule('maxLength', {
+				message: 'error message',
+				value: 3,
+			});
+			validateMax(maxWithMessage, 3);
+			expect(
+				(maxWithMessage as { maxLength: ValidationRuleWithParams }).maxLength
+					.$message
+			).toBe('error message');
+		});
+
+		test('creates required rule', () => {
+			const required = createRule('required', { value: true });
+			expect(required).toHaveProperty('required');
+			expect(
+				(required['required'] as unknown as ValidationRuleWithParams).$params
+			).toStrictEqual({
+				type: 'required',
+			});
+		});
+
+		test('Throw error with unsuppored rule', () => {
+			expect(() => createRule('foo', { value: true })).toThrow();
+		});
+	});
+});

--- a/src/utils/vuelidate.ts
+++ b/src/utils/vuelidate.ts
@@ -5,7 +5,6 @@ import {
 	PdapLengthRules,
 } from 'src/components/Form/types.ts';
 
-// TODO: Add tests
 /**
  * Type predicate to ensure the passed validator is a valid one.
  * @param s string to check against keys of the vuelidate validators object

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
 	test: {
 		coverage: {
 			all: true,
-			include: ['src/**/*.vue', 'utils/**/*.ts'],
+			include: ['src/**/*.vue', 'src/utils/**/*.ts'],
 			provider: 'v8',
 			reportsDirectory: './coverage',
 		},


### PR DESCRIPTION
Resolves #27 

In addition, tests have been updated to include:

- [ ] Coverage for updates to `QuickSearchForm`
- [ ] Small updates to **tests only** for `Form`, `Footer`, `Header`, `Nav` components
- [ ] New tests for all `vuelidate` utils exported from `src/utils/vuelidate`