### PR TITLE
refactor(components): add baseUrl prop to QuickSearchForm

### DIFF
--- a/src/components/QuickSearchForm/QuickSearchForm.vue
+++ b/src/components/QuickSearchForm/QuickSearchForm.vue
@@ -42,8 +42,8 @@ import { ref } from 'vue';
 
 const router = useRouter();
 
-const props = withDefaults(defineProps<{ mode: 'dev' | 'prod' }>(), {
-	mode: 'prod',
+const props = withDefaults(defineProps<{ baseUrl: string }>(), {
+	baseUrl: 'https://data-sources.pdap.io',
 });
 
 const formSchema = [
@@ -85,13 +85,7 @@ function handleSubmit(values: { location: string; searchTerm: string }) {
 	if (router.getRoutes().some((route) => route.path.includes('/search/'))) {
 		router.push(`/search/${searchTerm}/${location}`);
 	} else {
-		// Otherwise navigate via window
-		const baseUrl =
-			props.mode === 'prod'
-				? 'https://data-sources.pdap.io'
-				: 'https://data-sources.pdap.dev';
-
-		window.location.assign(`${baseUrl}/search/${searchTerm}/${location}`);
+		window.location.assign(`${props.baseUrl}/search/${searchTerm}/${location}`);
 	}
 }
 </script>

--- a/src/components/QuickSearchForm/QuickSearchForm.vue
+++ b/src/components/QuickSearchForm/QuickSearchForm.vue
@@ -42,8 +42,8 @@ import { ref } from 'vue';
 
 const router = useRouter();
 
-const props = withDefaults(defineProps<{ baseUrl: string }>(), {
-	baseUrl: 'https://data-sources.pdap.io',
+const props = withDefaults(defineProps<{ baseUrlForRedirect: string }>(), {
+	baseUrlForRedirect: 'https://data-sources.pdap.io',
 });
 
 const formSchema = [
@@ -85,7 +85,9 @@ function handleSubmit(values: { location: string; searchTerm: string }) {
 	if (router.getRoutes().some((route) => route.path.includes('/search/'))) {
 		router.push(`/search/${searchTerm}/${location}`);
 	} else {
-		window.location.assign(`${props.baseUrl}/search/${searchTerm}/${location}`);
+		window.location.assign(
+			`${props.baseUrlForRedirect}/search/${searchTerm}/${location}`
+		);
 	}
 }
 </script>

--- a/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
+++ b/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`QuickSearchForm component > Renders a QuickSearchForm 1`] = `
-<div class="pdap-flex-container pdap-flex-container-start md:p-0">
+<div class="pdap-flex-container pdap-flex-container-start p-0">
   <h2 class="mt-0">Search our database</h2>
-  <p class="pb-4 md:pb-8"> If you have a question to answer, we may already know about helpful data in your area. <routerlink to="/data">Learn more about the data here.</routerlink>
+  <p class="pb-4 md:pb-8"> If you have a question to answer, we may already know about helpful data in your area. <a href="https://pdap.io/data">Learn more about the data here.</a>
   </p>
 </div>
-<div class="pdap-flex-container pdap-flex-container-center pdap-quick-search-form h-full max-h-[75-vh] justify-start md:p-0">
+<div class="pdap-flex-container pdap-flex-container-center pdap-quick-search-form h-full max-h-[75-vh] justify-start p-0">
   <form class="pdap-form flex flex-wrap gap-x-4">
     <!--v-if-->
     <div class="pdap-grid-container pdap-input">

--- a/src/components/QuickSearchForm/quick-search-form.spec.ts
+++ b/src/components/QuickSearchForm/quick-search-form.spec.ts
@@ -167,7 +167,8 @@ describe('QuickSearchForm component', () => {
 		});
 	});
 
-	test('Form triggers window navigation when rendered in app without /search/ route — dev mode', async () => {
+	test('Form triggers window navigation when rendered in app without /search/ route — custom baseUrlForRedirect', async () => {
+		const baseUrlForRedirect = 'https://data-sources.pdap.dev';
 		getRoutes.mockReturnValueOnce([
 			{ path: '/' },
 			{ path: '/foo' },
@@ -177,7 +178,7 @@ describe('QuickSearchForm component', () => {
 		const wrapper = mount(QuickSearchForm, {
 			...base,
 			props: {
-				mode: 'dev' as const,
+				baseUrlForRedirect,
 			},
 		});
 


### PR DESCRIPTION
Swaps `mode` prop for `baseUrlForRedirect` in `QuickSearchForm` component.

This will allow consuming client apps (mostly `pdap.io` at this point) to pass a base url for redirecting to whichever `/search...` is appropriate based on the mode the app is running in.

Made the choice to swap the logic to the calling application, because the component is simpler if it doesn't have to know about that. Its only job is the redirect.