### PR TITLE
feat: add email and password validators to form

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,5 +26,13 @@ module.exports = {
 	],
 	rules: {
 		"@typescript-eslint/indent": "off",
+		"@typescript-eslint/ban-ts-comment": [
+			"error", {
+				'ts-expect-error': false,
+				'ts-ignore': true,
+				'ts-nocheck': true,
+				'ts-check': false,
+				minimumDescriptionLength: 3,		
+		}]
 	}
 }

--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -17,16 +17,8 @@
 					: ''
 			"
 			:value="values[field.name]"
-			@change="
-				field.type !== PdapInputTypes.TEXT
-					? updateForm(field.name, $event)
-					: undefined
-			"
-			@input="
-				field.type === PdapInputTypes.TEXT
-					? updateForm(field.name, $event)
-					: undefined
-			"
+			@change="updateForm(field.name, $event)"
+			@input="updateForm(field.name, $event)"
 		/>
 		<slot />
 	</form>

--- a/src/components/Form/__snapshots__/form.spec.ts.snap
+++ b/src/components/Form/__snapshots__/form.spec.ts.snap
@@ -19,8 +19,9 @@ exports[`Form component > Renders component in form error state 1`] = `
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
-    <input id="test-password" name="password" placeholder="Password" type="text"><!-- Password -->
     <!--v-if-->
+    <!-- Password -->
+    <input id="test-password" name="password" placeholder="Password" type="password">
     <!--v-if-->
     <label class="pdap-input-label" for="test-password">Password test input</label>
   </div>
@@ -72,8 +73,9 @@ exports[`Form component > Renders component in static state 1`] = `
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
-    <input id="test-password" name="password" placeholder="Password" type="text"><!-- Password -->
     <!--v-if-->
+    <!-- Password -->
+    <input id="test-password" name="password" placeholder="Password" type="password">
     <!--v-if-->
     <label class="pdap-input-label" for="test-password">Password test input</label>
   </div>

--- a/src/components/Form/__snapshots__/form.spec.ts.snap
+++ b/src/components/Form/__snapshots__/form.spec.ts.snap
@@ -5,18 +5,36 @@ exports[`Form component > Renders component in form error state 1`] = `
   <div class="pdap-form-error-message">This form is incorrect</div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
-    <input id="test-1" name="testOne" placeholder="Enter a value here" type="text">
+    <input id="test-1" name="testOne" placeholder="Enter a value here" type="text"><!-- Password -->
+    <!--v-if-->
     <!--v-if-->
     <label class="pdap-input-label" for="test-1">First test input</label>
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
-    <input id="test-2" name="testTwo" placeholder="Enter another value here" type="text">
+    <input id="test-email" name="email" placeholder="Email" type="text"><!-- Password -->
+    <!--v-if-->
+    <!--v-if-->
+    <label class="pdap-input-label" for="test-email">Email test input</label>
+  </div>
+  <div class="pdap-grid-container pdap-input">
+    <!-- Text -->
+    <input id="test-password" name="password" placeholder="Password" type="text"><!-- Password -->
+    <!--v-if-->
+    <!--v-if-->
+    <label class="pdap-input-label" for="test-password">Password test input</label>
+  </div>
+  <div class="pdap-grid-container pdap-input">
+    <!-- Text -->
+    <input id="test-2" name="testTwo" placeholder="Enter another value here" type="text"><!-- Password -->
+    <!--v-if-->
     <!--v-if-->
     <label class="pdap-input-label" for="test-2">Second test input</label>
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
+    <!--v-if-->
+    <!-- Password -->
     <!-- Checkbox -->
     <input checked class="pdap-input-checkbox" id="checkbox-default-checked" name="checkboxDefaultChecked" type="checkbox" value="true">
     <!--v-if-->
@@ -24,6 +42,8 @@ exports[`Form component > Renders component in form error state 1`] = `
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
+    <!--v-if-->
+    <!-- Password -->
     <!-- Checkbox -->
     <input class="pdap-input-checkbox" id="checkbox-default-unchecked" name="checkboxDefaultUnchecked" type="checkbox" value="false">
     <!--v-if-->
@@ -38,18 +58,36 @@ exports[`Form component > Renders component in static state 1`] = `
   <!--v-if-->
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
-    <input id="test-1" name="testOne" placeholder="Enter a value here" type="text">
+    <input id="test-1" name="testOne" placeholder="Enter a value here" type="text"><!-- Password -->
+    <!--v-if-->
     <!--v-if-->
     <label class="pdap-input-label" for="test-1">First test input</label>
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
-    <input id="test-2" name="testTwo" placeholder="Enter another value here" type="text">
+    <input id="test-email" name="email" placeholder="Email" type="text"><!-- Password -->
+    <!--v-if-->
+    <!--v-if-->
+    <label class="pdap-input-label" for="test-email">Email test input</label>
+  </div>
+  <div class="pdap-grid-container pdap-input">
+    <!-- Text -->
+    <input id="test-password" name="password" placeholder="Password" type="text"><!-- Password -->
+    <!--v-if-->
+    <!--v-if-->
+    <label class="pdap-input-label" for="test-password">Password test input</label>
+  </div>
+  <div class="pdap-grid-container pdap-input">
+    <!-- Text -->
+    <input id="test-2" name="testTwo" placeholder="Enter another value here" type="text"><!-- Password -->
+    <!--v-if-->
     <!--v-if-->
     <label class="pdap-input-label" for="test-2">Second test input</label>
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
+    <!--v-if-->
+    <!-- Password -->
     <!-- Checkbox -->
     <input checked class="pdap-input-checkbox" id="checkbox-default-checked" name="checkboxDefaultChecked" type="checkbox" value="true">
     <!--v-if-->
@@ -57,6 +95,8 @@ exports[`Form component > Renders component in static state 1`] = `
   </div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
+    <!--v-if-->
+    <!-- Password -->
     <!-- Checkbox -->
     <input class="pdap-input-checkbox" id="checkbox-default-unchecked" name="checkboxDefaultUnchecked" type="checkbox" value="false">
     <!--v-if-->

--- a/src/components/Form/form.spec.ts
+++ b/src/components/Form/form.spec.ts
@@ -23,6 +23,35 @@ const schema = [
 		},
 	},
 	{
+		id: 'test-email',
+		label: 'Email test input',
+		name: 'email',
+		placeholder: 'Email',
+		type: PdapInputTypes.TEXT,
+		value: '',
+		validators: {
+			email: {
+				message: 'Please enter a valid email address',
+				value: true,
+			},
+		},
+	},
+	{
+		id: 'test-password',
+		label: 'Password test input',
+		name: 'password',
+		placeholder: 'Password',
+		type: PdapInputTypes.TEXT,
+		value: '',
+		validators: {
+			password: {
+				message:
+					'Please enter a password of 8 characters, with at least one capital letter, one lowercase letter, one number, and one special character',
+				value: true,
+			},
+		},
+	},
+	{
 		id: 'test-2',
 		label: 'Second test input',
 		name: 'testTwo',
@@ -133,6 +162,8 @@ describe('Form component', () => {
 		// Get elements
 		const inputTextOne = await wrapper.find('#test-1');
 		const inputTextTwo = await wrapper.find('#test-2');
+		const inputEmail = await wrapper.find('#test-email');
+		const inputPassword = await wrapper.find('#test-password');
 		const inputCheckboxDefaultChecked = await wrapper.find(
 			'#checkbox-default-checked'
 		);
@@ -144,6 +175,8 @@ describe('Form component', () => {
 		const elements = [
 			inputTextOne,
 			inputTextTwo,
+			inputEmail,
+			inputPassword,
 			inputCheckboxDefaultChecked,
 			inputCheckboxDefaultUnchecked,
 		];
@@ -152,7 +185,7 @@ describe('Form component', () => {
 		elements.forEach((element) => {
 			expect(element.exists()).toBe(true);
 		});
-		elements.slice(0, 1).forEach((element) => {
+		elements.slice(0, 3).forEach((element) => {
 			expect((element.element as HTMLInputElement).value).toBe('');
 		});
 		expect(
@@ -165,6 +198,8 @@ describe('Form component', () => {
 		// Interact with elements
 		await inputTextOne.setValue('foo');
 		await inputTextTwo.setValue('bar');
+		await inputEmail.setValue('hello@hello.com');
+		await inputPassword.setValue('P@ssword1!');
 		await inputCheckboxDefaultChecked.trigger('change');
 		await inputCheckboxDefaultUnchecked.trigger('change');
 		await nextTick();
@@ -172,6 +207,12 @@ describe('Form component', () => {
 		// Assert new values
 		expect((inputTextOne.element as HTMLInputElement).value).toBe('foo');
 		expect((inputTextTwo.element as HTMLInputElement).value).toBe('bar');
+		expect((inputEmail.element as HTMLInputElement).value).toBe(
+			'hello@hello.com'
+		);
+		expect((inputPassword.element as HTMLInputElement).value).toBe(
+			'P@ssword1!'
+		);
 		expect(
 			(inputCheckboxDefaultChecked.element as HTMLInputElement).value
 		).toBe('false');
@@ -185,10 +226,15 @@ describe('Form component', () => {
 
 		const inputTextOne = wrapper.find('#test-1');
 		const inputTextTwo = wrapper.find('#test-2');
+		const inputEmail = await wrapper.find('#test-email');
+		const inputPassword = await wrapper.find('#test-password');
+
 		await nextTick();
 
 		await inputTextOne.setValue('foo');
 		await inputTextTwo.setValue('bar');
+		await inputEmail.setValue('hello@hello.com');
+		await inputPassword.setValue('P@ssword1!');
 
 		await wrapper.find('form').trigger('submit');
 		await nextTick();
@@ -197,6 +243,8 @@ describe('Form component', () => {
 		expect(wrapper.emitted('submit')?.[0][0]).toStrictEqual({
 			checkboxDefaultChecked: 'true',
 			checkboxDefaultUnchecked: 'false',
+			email: 'hello@hello.com',
+			password: 'P@ssword1!',
 			testOne: 'foo',
 			testTwo: 'bar',
 		});
@@ -208,10 +256,14 @@ describe('Form component', () => {
 
 		const inputTextOne = wrapper.find('#test-1');
 		const inputTextTwo = wrapper.find('#test-2');
+		const inputEmail = await wrapper.find('#test-email');
+		const inputPassword = await wrapper.find('#test-password');
 		await nextTick();
 
 		await inputTextOne.setValue('');
 		await inputTextTwo.setValue('a');
+		await inputEmail.setValue('hello');
+		await inputPassword.setValue('Pass');
 		await nextTick();
 
 		await wrapper.find('form').trigger('submit');
@@ -228,7 +280,8 @@ describe('Form component', () => {
 		// Set values to correct values
 		await inputTextOne.setValue('aaaaa');
 		await inputTextTwo.setValue('bvvvvv');
-
+		await inputEmail.setValue('hello@hello.com');
+		await inputPassword.setValue('P@ssword1!');
 		await nextTick();
 		wrapper.vm.$forceUpdate();
 

--- a/src/components/Form/form.spec.ts
+++ b/src/components/Form/form.spec.ts
@@ -41,7 +41,7 @@ const schema = [
 		label: 'Password test input',
 		name: 'password',
 		placeholder: 'Password',
-		type: PdapInputTypes.TEXT,
+		type: PdapInputTypes.PASSWORD,
 		value: '',
 		validators: {
 			password: {

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -17,6 +17,8 @@ export interface PdapFormValidators {
 	maxLength: PdapFormValidator<number>;
 	minLength: PdapFormValidator<number>;
 	required: PdapFormValidator<boolean>;
+	email: PdapFormValidator<boolean>;
+	password: PdapFormValidator<boolean>;
 }
 
 export interface PdapFormInputProps

--- a/src/components/Input/PdapInput.vue
+++ b/src/components/Input/PdapInput.vue
@@ -16,6 +16,18 @@
 			v-bind="$attrs"
 			@input="input"
 		/>
+		
+		<!-- Password -->
+		<input
+			v-if="type === PdapInputTypes.PASSWORD"
+			:id="id"
+			type="password"
+			:name="name"
+			:placeholder="placeholder"
+			:value="value"
+			v-bind="$attrs"
+			@input="input"
+		/>
 
 		<!-- Checkbox -->
 		<input

--- a/src/components/Input/__snapshots__/input.spec.ts.snap
+++ b/src/components/Input/__snapshots__/input.spec.ts.snap
@@ -3,6 +3,8 @@
 exports[`Input component > Renders checkbox input in error state 1`] = `
 <div class="pdap-grid-container pdap-input pdap-input-error">
   <!-- Text -->
+  <!--v-if-->
+  <!-- Password -->
   <!-- Checkbox -->
   <input class="pdap-input-checkbox" id="test-checked" name="testCheckbox" type="checkbox">
   <div class="pdap-input-error-message" id="pdap-testCheckbox-input-error">error message</div>
@@ -13,6 +15,8 @@ exports[`Input component > Renders checkbox input in error state 1`] = `
 exports[`Input component > Renders checkbox input in okay state 1`] = `
 <div class="pdap-grid-container pdap-input">
   <!-- Text -->
+  <!--v-if-->
+  <!-- Password -->
   <!-- Checkbox -->
   <input class="pdap-input-checkbox" id="test-checked" name="testCheckbox" type="checkbox">
   <!--v-if-->
@@ -20,10 +24,33 @@ exports[`Input component > Renders checkbox input in okay state 1`] = `
 </div>
 `;
 
+exports[`Input component > Renders password input in error state 1`] = `
+<div class="pdap-grid-container pdap-input pdap-input-error">
+  <!-- Text -->
+  <!--v-if-->
+  <!-- Password -->
+  <input id="test-text" name="testText" placeholder="This is testing testing" type="password">
+  <div class="pdap-input-error-message" id="pdap-testText-input-error">error message</div>
+  <label class="pdap-input-label" for="test-text">test this text input</label>
+</div>
+`;
+
+exports[`Input component > Renders password input in okay state 1`] = `
+<div class="pdap-grid-container pdap-input">
+  <!-- Text -->
+  <!--v-if-->
+  <!-- Password -->
+  <input id="test-text" name="testText" placeholder="This is testing testing" type="password">
+  <!--v-if-->
+  <label class="pdap-input-label" for="test-text">test this text input</label>
+</div>
+`;
+
 exports[`Input component > Renders text input in error state 1`] = `
 <div class="pdap-grid-container pdap-input pdap-input-error">
   <!-- Text -->
-  <input id="test-text" name="testText" placeholder="This is testing testing" type="text">
+  <input id="test-text" name="testText" placeholder="This is testing testing" type="text"><!-- Password -->
+  <!--v-if-->
   <div class="pdap-input-error-message" id="pdap-testText-input-error">error message</div>
   <label class="pdap-input-label" for="test-text">test this text input</label>
 </div>
@@ -32,7 +59,8 @@ exports[`Input component > Renders text input in error state 1`] = `
 exports[`Input component > Renders text input in okay state 1`] = `
 <div class="pdap-grid-container pdap-input">
   <!-- Text -->
-  <input id="test-text" name="testText" placeholder="This is testing testing" type="text">
+  <input id="test-text" name="testText" placeholder="This is testing testing" type="text"><!-- Password -->
+  <!--v-if-->
   <!--v-if-->
   <label class="pdap-input-label" for="test-text">test this text input</label>
 </div>

--- a/src/components/Input/input.spec.ts
+++ b/src/components/Input/input.spec.ts
@@ -54,7 +54,10 @@ describe('Input component', () => {
 	});
 
 	test('Renders password input in okay state', () => {
-		const wrapper = mount(PdapInput, {...baseText, props: {...baseText.props, type: PdapInputTypes.PASSWORD}});
+		const wrapper = mount(PdapInput, {
+			...baseText,
+			props: { ...baseText.props, type: PdapInputTypes.PASSWORD },
+		});
 
 		expect(
 			wrapper.find('.pdap-input').find('input[type="password"]').exists()
@@ -66,7 +69,11 @@ describe('Input component', () => {
 	test('Renders password input in error state', () => {
 		const wrapper = mount(PdapInput, {
 			...baseText,
-			props: { ...baseText.props, error: 'error message', type: PdapInputTypes.PASSWORD},
+			props: {
+				...baseText.props,
+				error: 'error message',
+				type: PdapInputTypes.PASSWORD,
+			},
 		});
 
 		expect(

--- a/src/components/Input/input.spec.ts
+++ b/src/components/Input/input.spec.ts
@@ -53,6 +53,29 @@ describe('Input component', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
+	test('Renders password input in okay state', () => {
+		const wrapper = mount(PdapInput, {...baseText, props: {...baseText.props, type: PdapInputTypes.PASSWORD}});
+
+		expect(
+			wrapper.find('.pdap-input').find('input[type="password"]').exists()
+		).toBe(true);
+		expect(wrapper.find('.pdap-input-error-message').exists()).toBe(false);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	test('Renders password input in error state', () => {
+		const wrapper = mount(PdapInput, {
+			...baseText,
+			props: { ...baseText.props, error: 'error message', type: PdapInputTypes.PASSWORD},
+		});
+
+		expect(
+			wrapper.find('.pdap-input').find('input[type="password"]').exists()
+		).toBe(true);
+		expect(wrapper.find('.pdap-input-error-message').exists()).toBe(true);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
 	test('Renders checkbox input in okay state', () => {
 		const wrapper = mount(PdapInput, baseCheckbox);
 

--- a/src/components/Input/types.ts
+++ b/src/components/Input/types.ts
@@ -1,6 +1,7 @@
 export enum PdapInputTypes {
 	CHECKBOX = 'checkbox',
 	TEXT = 'text',
+	PASSWORD = 'password',
 }
 
 export interface PdapInputBaseProps {

--- a/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
+++ b/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
@@ -11,13 +11,15 @@ exports[`QuickSearchForm component > Renders a QuickSearchForm 1`] = `
     <!--v-if-->
     <div class="pdap-grid-container pdap-input">
       <!-- Text -->
-      <input id="search-term" name="searchTerm" placeholder="Enter a keyword, or &#x27;all&#x27;" type="text">
+      <input id="search-term" name="searchTerm" placeholder="Enter a keyword, or &#x27;all&#x27;" type="text"><!-- Password -->
+      <!--v-if-->
       <!--v-if-->
       <label class="pdap-input-label" for="search-term">What are you looking for?</label>
     </div>
     <div class="pdap-grid-container pdap-input">
       <!-- Text -->
-      <input id="location" name="location" placeholder="Enter a place, or &#x27;all&#x27;" type="text">
+      <input id="location" name="location" placeholder="Enter a place, or &#x27;all&#x27;" type="text"><!-- Password -->
+      <!--v-if-->
       <!--v-if-->
       <label class="pdap-input-label" for="location">From where?</label>
     </div>

--- a/src/utils/vuelidate.test.ts
+++ b/src/utils/vuelidate.test.ts
@@ -4,8 +4,12 @@ import {
 	createRule,
 	isLengthRule,
 	isPdapVuelidateValidator,
+	makeEmailRule,
+	makeEmailRuleWithCustomMessage,
 	makeLengthRule,
 	makeLengthRuleWithCustomMessage,
+	makePasswordRule,
+	makePasswordRuleWithCustomMessage,
 	makeRequiredRule,
 	makeRequiredRuleWithCustomMessage,
 } from './vuelidate';
@@ -78,6 +82,38 @@ describe('Vuelidate utils', () => {
 		expect(requiredWithMessage['required'].$message).toBe('error message');
 	});
 
+	test('makeEmailRule', () => {
+		const email = makeEmailRule();
+		expect(email).toHaveProperty('email');
+		expect(
+			(email.email as unknown as ValidationRuleWithParams).$params
+		).toStrictEqual({
+			type: 'email',
+		});
+	});
+
+	test('makeEmailRuleWithMessage', () => {
+		const emailWithMessage = makeEmailRuleWithCustomMessage('error message');
+		expect(emailWithMessage).toHaveProperty('email');
+		expect(
+			(emailWithMessage.email as unknown as ValidationRuleWithParams).$params
+		).toStrictEqual({
+			type: 'email',
+		});
+		expect(emailWithMessage.email.$message).toBe('error message');
+	});
+
+	test('makePasswordRule', () => {
+		const password = makePasswordRule();
+		expect(typeof password.password).toBe('function');
+	});
+
+	test('makePasswordRuleWithCustomMessage', () => {
+		const password = makePasswordRuleWithCustomMessage('error message');
+		expect(typeof password.password.$validator).toBe('function');
+		expect(password.password.$message).toBe('error message');
+	});
+
 	describe('createRule', () => {
 		test('creates length rules', () => {
 			const max = createRule('maxLength', { value: 3 });
@@ -93,14 +129,67 @@ describe('Vuelidate utils', () => {
 			).toBe('error message');
 		});
 
-		test('creates required rule', () => {
+		test('creates required rules', () => {
 			const required = createRule('required', { value: true });
 			expect(required).toHaveProperty('required');
-			expect(
-				(required['required'] as unknown as ValidationRuleWithParams).$params
-			).toStrictEqual({
+			// @ts-expect-error
+			expect(required?.required.$params).toStrictEqual({
 				type: 'required',
 			});
+
+			const requiredWithMessage = createRule('required', {
+				value: true,
+				message: 'error message',
+			});
+			expect(requiredWithMessage).toHaveProperty('required');
+
+			// @ts-expect-error
+			expect(requiredWithMessage?.required.$params).toStrictEqual({
+				type: 'required',
+			});
+
+			// @ts-expect-error
+			expect(requiredWithMessage.required.$message).toBe('error message');
+		});
+
+		test('creates email rules', () => {
+			const email = createRule('email', { value: true });
+			expect(email).toHaveProperty('email');
+			// @ts-expect-error
+			expect(email?.email.$params).toStrictEqual({
+				type: 'email',
+			});
+
+			const emailWithMessage = createRule('email', {
+				value: true,
+				message: 'error message',
+			});
+			expect(emailWithMessage).toHaveProperty('email');
+
+			// @ts-expect-error
+			expect(emailWithMessage?.email.$params).toStrictEqual({
+				type: 'email',
+			});
+			
+			// @ts-expect-error
+			expect(emailWithMessage.email.$message).toBe('error message');
+		});
+
+		test('creates password rules', () => {
+			const password = createRule('password', { value: true });
+			expect(password).toHaveProperty('password');
+			expect(typeof (password as { password: () => void }).password).toBe(
+				'function'
+			);
+
+			const passwordWithMessage = createRule('password', {
+				value: true,
+				message: 'error message',
+			});
+			// @ts-expect-error
+			expect(typeof passwordWithMessage.password.$validator).toBe('function');
+			// @ts-expect-error
+			expect(passwordWithMessage.password.$message).toBe('error message');
 		});
 
 		test('Throw error with unsuppored rule', () => {

--- a/src/utils/vuelidate.test.ts
+++ b/src/utils/vuelidate.test.ts
@@ -170,7 +170,7 @@ describe('Vuelidate utils', () => {
 			expect(emailWithMessage?.email.$params).toStrictEqual({
 				type: 'email',
 			});
-			
+
 			// @ts-expect-error
 			expect(emailWithMessage.email.$message).toBe('error message');
 		});


### PR DESCRIPTION
Resolves #48 

## To test

 - Observe [successful test run](https://github.com/Police-Data-Accessibility-Project/design-system/actions/runs/7804607765/job/21286969963?pr=50) on this branch.
 - See this screen recording, where a basic signin form uses the new validation via local symlink.


https://github.com/Police-Data-Accessibility-Project/design-system/assets/68428039/6568c2b8-31fb-407b-a4b3-528a32ea96a6

(The above is using a `text` input to demonstrate, but we will use a `password` input to automatically mask the value—that support is added in this PR as well)
