### PR TITLE
refactor(components): update form

### DIFF
--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -3,6 +3,7 @@
 		:id="id"
 		:name="name"
 		class="pdap-form"
+		@change="change"
 		@submit.prevent="submit($event)"
 	>
 		<div
@@ -50,7 +51,7 @@ const props = withDefaults(defineProps<PdapFormProps>(), {
 });
 
 // Emits
-const emit = defineEmits(['submit']);
+const emit = defineEmits(['submit', 'change']);
 
 // State
 const data = computed(() =>
@@ -102,6 +103,7 @@ const errorMessage = ref(props.error);
 // Handlers
 function updateForm(fieldName: string, value: string) {
 	values[fieldName] = value;
+	change();
 }
 
 // Effects
@@ -128,6 +130,10 @@ watchEffect(() => {
 		},
 	});
 });
+
+function change() {
+	emit('change', { ...values });
+}
 
 async function submit(event: Event) {
 	// Check form submission

--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -1,5 +1,10 @@
 <template>
-	<form class="pdap-form" @submit.prevent="submit($event)">
+	<form
+		:id="id"
+		:name="name"
+		class="pdap-form"
+		@submit.prevent="submit($event)"
+	>
 		<div
 			v-if="typeof errorMessage === 'string'"
 			class="pdap-form-error-message"
@@ -26,7 +31,7 @@
 
 <script setup lang="ts">
 // Globals
-import { ref, watchEffect } from 'vue';
+import { computed, reactive, ref, watchEffect } from 'vue';
 import { useVuelidate } from '@vuelidate/core';
 
 // Components
@@ -48,7 +53,7 @@ const props = withDefaults(defineProps<PdapFormProps>(), {
 const emit = defineEmits(['submit']);
 
 // State
-const data = ref<typeof props.schema>(
+const data = computed(() =>
 	props.schema.map((input) => {
 		const newInput = { ...input };
 		delete newInput.validators;
@@ -57,12 +62,13 @@ const data = ref<typeof props.schema>(
 	})
 );
 
-const values = ref<Record<string, string>>(
-	props.schema.reduce((acc, input) => {
+let values = reactive<Record<string, string>>(
+	data.value.reduce((acc, input) => {
 		switch (input.type) {
 			case PdapInputTypes.CHECKBOX:
 				return { ...acc, [input.name]: String(input.defaultChecked) };
 			case PdapInputTypes.TEXT:
+			case PdapInputTypes.PASSWORD:
 			default:
 				return { ...acc, [input.name]: input.value };
 		}
@@ -95,7 +101,7 @@ const errorMessage = ref(props.error);
 
 // Handlers
 function updateForm(fieldName: string, value: string) {
-	values.value[fieldName] = value;
+	values[fieldName] = value;
 }
 
 // Effects
@@ -113,6 +119,8 @@ watchEffect(() => {
 	console.debug(`PdapForm ${props.name}\n`, {
 		errorMessage: errorMessage.value,
 		props,
+		schema: props.schema,
+		data,
 		values,
 		vuelidate: {
 			rules,
@@ -126,14 +134,14 @@ async function submit(event: Event) {
 	const isValidSubmission = await v$.value.$validate();
 	if (isValidSubmission) {
 		// Emit submit event (spread to new object to create new object, this allows us to reset `values` without messing with the data returned)
-		emit('submit', { ...values.value });
+		emit('submit', { ...values });
 		// Reset vuelidate and form
 		v$.value.$reset();
 		const form = <HTMLFormElement>event.target;
 		form.reset();
 
 		// Wipe values state ('' for text inputs, as-was for everything else)
-		values.value = Object.entries(values.value).reduce((acc, [key, value]) => {
+		values = Object.entries(values).reduce((acc, [key, value]) => {
 			return { ...acc, [key]: ['true', 'false'].includes(value) ? value : '' };
 		}, {});
 		return;

--- a/src/components/Form/__snapshots__/form.spec.ts.snap
+++ b/src/components/Form/__snapshots__/form.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Form component > Renders component in form error state 1`] = `
-<form class="pdap-form">
+<form class="pdap-form" id="test" name="test">
   <div class="pdap-form-error-message">This form is incorrect</div>
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->
@@ -55,7 +55,7 @@ exports[`Form component > Renders component in form error state 1`] = `
 `;
 
 exports[`Form component > Renders component in static state 1`] = `
-<form class="pdap-form">
+<form class="pdap-form" id="test" name="test">
   <!--v-if-->
   <div class="pdap-grid-container pdap-input">
     <!-- Text -->

--- a/src/components/QuickSearchForm/QuickSearchForm.vue
+++ b/src/components/QuickSearchForm/QuickSearchForm.vue
@@ -17,6 +17,7 @@
 			:error="error"
 			:schema="formSchema"
 			name="quickSearchForm"
+			@change="handleChange"
 			@submit="handleSubmit"
 		>
 			<Button
@@ -66,6 +67,15 @@ const formSchema = [
 ];
 
 const error = ref<string | undefined>(undefined);
+
+function handleChange(values: { location: string; searchTerm: string }) {
+	// Reset error on form change
+	if (error.value) {
+		if (Object.values(values).some(Boolean)) {
+			error.value = undefined;
+		}
+	}
+}
 
 function handleSubmit(values: { location: string; searchTerm: string }) {
 	/**  Extra validation - backend expects 1 form value to be filled in.

--- a/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
+++ b/src/components/QuickSearchForm/__snapshots__/quick-search-form.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`QuickSearchForm component > Renders a QuickSearchForm 1`] = `
   </p>
 </div>
 <div class="pdap-flex-container pdap-flex-container-center pdap-quick-search-form h-full max-h-[75-vh] justify-start p-0">
-  <form class="pdap-form flex flex-wrap gap-x-4">
+  <form class="pdap-form flex flex-wrap gap-x-4" id="quick-search-form" name="quickSearchForm">
     <!--v-if-->
     <div class="pdap-grid-container pdap-input">
       <!-- Text -->

--- a/src/components/QuickSearchForm/quick-search-form.spec.ts
+++ b/src/components/QuickSearchForm/quick-search-form.spec.ts
@@ -200,7 +200,7 @@ describe('QuickSearchForm component', () => {
 		);
 	});
 
-	test('Form errors when submitted with both inputs blank', async () => {
+	test('Form errors when submitted with both inputs blank and clears error on input', async () => {
 		const wrapper = mount(QuickSearchForm, base);
 
 		// Submit
@@ -213,5 +213,10 @@ describe('QuickSearchForm component', () => {
 		expect(wrapper.get('.pdap-form-error-message').text()).toBe(
 			'Either a search term or a location is required.'
 		);
+
+		const searchInput = wrapper.find('#search-term');
+		await searchInput.setValue('foo');
+		await nextTick();
+		expect(wrapper.find('.pdap-form-error-message').exists()).toBe(false);
 	});
 });


### PR DESCRIPTION
Ensure Form props passed to form element (`id` and `name` were missing)
Ensure data update on schema change (use `reactive` instead of `ref`)
Add `change` emit to Form (for clearing custom errors)
Use `change` event emitted by `Form` for clearing custom error handling in `QuickSearchForm`