### PR TITLE
fix: preserve form input values on custom form validation

### DIFF
--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -4,7 +4,7 @@
 		:name="name"
 		class="pdap-form"
 		@change="change"
-		@submit.prevent="submit($event)"
+		@submit.prevent="submit()"
 	>
 		<div
 			v-if="typeof errorMessage === 'string'"
@@ -140,7 +140,7 @@ function change() {
 	emit('change', { ...values.value });
 }
 
-async function submit(event: Event) {
+async function submit() {
 	// Check form submission
 	const isValidSubmission = await v$.value.$validate();
 	if (isValidSubmission) {

--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -17,7 +17,7 @@
 					: ''
 			"
 			:value="values[field.name]"
-			@input="updateForm(field.name, $event)"
+			@input="updateForm(field, $event)"
 		/>
 		<slot />
 	</form>
@@ -36,7 +36,7 @@ import { createRule } from '../../utils/vuelidate';
 
 // Types
 import { PdapFormProps } from './types';
-import { PdapInputTypes } from '../Input/types';
+import { PdapInputProps, PdapInputTypes } from '../Input/types';
 
 // Props
 const props = withDefaults(defineProps<PdapFormProps>(), {
@@ -92,10 +92,19 @@ const v$ = useVuelidate(rules, values, { $autoDirty: false, $lazy: true });
 const errorMessage = ref(props.error);
 
 // Handlers
-function updateForm(fieldName: string, event: Event) {
+function updateForm(field: PdapInputProps, event: Event) {
 	const target = event.target as HTMLInputElement;
 
-	values.value[fieldName] = target.value;
+	const update = (() => {
+		switch (field.type) {
+			case PdapInputTypes.CHECKBOX:
+				return target.checked ? 'true' : 'false';
+			default:
+				return target.value;
+		}
+	})();
+
+	values.value[field.name] = update;
 	emit('change', values.value);
 }
 

--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -94,13 +94,8 @@ const errorMessage = ref(props.error);
 // Handlers
 function updateForm(fieldName: string, event: Event) {
 	const target = event.target as HTMLInputElement;
-	const update =
-		target.type === PdapInputTypes.CHECKBOX &&
-		typeof target.checked === 'boolean'
-			? target.checked.toString()
-			: target.value;
 
-	values.value[fieldName] = update;
+	values.value[fieldName] = target.value;
 	emit('change', values.value);
 }
 

--- a/src/components/Form/PdapForm.vue
+++ b/src/components/Form/PdapForm.vue
@@ -1,11 +1,5 @@
 <template>
-	<form
-		:id="id"
-		:name="name"
-		class="pdap-form"
-		@change="change"
-		@submit.prevent="submit()"
-	>
+	<form :id="id" :name="name" class="pdap-form" @submit.prevent="submit">
 		<div
 			v-if="typeof errorMessage === 'string'"
 			class="pdap-form-error-message"
@@ -23,7 +17,7 @@
 					: ''
 			"
 			:value="values[field.name]"
-			@change="updateForm(field.name, $event)"
+			@input="updateForm(field.name, $event)"
 		/>
 		<slot />
 	</form>
@@ -107,7 +101,7 @@ function updateForm(fieldName: string, event: Event) {
 			: target.value;
 
 	values.value[fieldName] = update;
-	change();
+	emit('change', values.value);
 }
 
 // Effects
@@ -134,10 +128,6 @@ function resetForm() {
 	values.value = Object.entries(values).reduce((acc, [key]) => {
 		return { ...acc, [key]: '' };
 	}, {});
-}
-
-function change() {
-	emit('change', { ...values.value });
 }
 
 async function submit() {

--- a/src/components/Form/README.md
+++ b/src/components/Form/README.md
@@ -4,12 +4,13 @@ The `Form` component is powerful. All you need to do is pass a few props, and th
 
 ## Props
 
-| name     | required? | types                                                    | description                        | default     |
-| -------- | --------- | -------------------------------------------------------- | ---------------------------------- | ----------- |
-| `error`  | no        | `string` \| `undefined` \| `null`                        | Error state                        | `undefined` |
-| `id`     | yes       | `string`                                                 | Form id                            | none        |
-| `name`   | yes       | `string`                                                 | Form name                          | none        |
-| `schema` | yes       | `PdapFormSchema` (array of `PdapFormInputProps` objects) | Array of schema entries for inputs | none        |
+| name      | required? | types                                                    | description                                                                                                                             | default     |
+| --------- | --------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `error`   | no        | `string` \| `undefined` \| `null`                        | Error state                                                                                                                             | `undefined` |
+| `id`      | yes       | `string`                                                 | Form id                                                                                                                                 | none        |
+| `name`    | yes       | `string`                                                 | Form name                                                                                                                               | none        |
+| `schema`  | yes       | `PdapFormSchema` (array of `PdapFormInputProps` objects) | Array of schema entries for inputs                                                                                                      | none        |
+| `resetOn` | no        | `'submit'` \| `boolean`                                  | When to reset form - if `'submit'`, it happens during submission. If `boolean`, it happens when the value of the prop changes to `true` | none        |
 
 
 
@@ -70,6 +71,8 @@ PdapFormValidators {
 ```
 
 ## Example
+
+Note: to observe `resetOn`, see the [demo page](../../demo/pages/SignupFormDemo.vue)
 
 ```
 <template>

--- a/src/components/Form/README.md
+++ b/src/components/Form/README.md
@@ -4,13 +4,13 @@ The `Form` component is powerful. All you need to do is pass a few props, and th
 
 ## Props
 
-| name      | required? | types                                                    | description                                                                                                                             | default     |
-| --------- | --------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `error`   | no        | `string` \| `undefined` \| `null`                        | Error state                                                                                                                             | `undefined` |
-| `id`      | yes       | `string`                                                 | Form id                                                                                                                                 | none        |
-| `name`    | yes       | `string`                                                 | Form name                                                                                                                               | none        |
-| `schema`  | yes       | `PdapFormSchema` (array of `PdapFormInputProps` objects) | Array of schema entries for inputs                                                                                                      | none        |
-| `resetOn` | no        | `'submit'` \| `boolean`                                  | When to reset form - if `'submit'`, it happens during submission. If `boolean`, it happens when the value of the prop changes to `true` | none        |
+| name      | required? | types                                                    | description                                                                                                                    | default     |
+| --------- | --------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `error`   | no        | `string` \| `undefined` \| `null`                        | Error state                                                                                                                    | `undefined` |
+| `id`      | yes       | `string`                                                 | Form id                                                                                                                        | none        |
+| `name`    | yes       | `string`                                                 | Form name                                                                                                                      | none        |
+| `schema`  | yes       | `PdapFormSchema` (array of `PdapFormInputProps` objects) | Array of schema entries for inputs                                                                                             | none        |
+| `resetOn` | no        | `'submit'` \| `boolean`                                  | When to reset form - if `'submit'`, it happens during submission. If `boolean`, it happens on any change of the prop to `true` | `'submit'`  |
 
 
 

--- a/src/components/Form/form.spec.ts
+++ b/src/components/Form/form.spec.ts
@@ -200,8 +200,8 @@ describe('Form component', () => {
 		await inputTextTwo.setValue('bar');
 		await inputEmail.setValue('hello@hello.com');
 		await inputPassword.setValue('P@ssword1!');
-		await inputCheckboxDefaultChecked.trigger('change');
-		await inputCheckboxDefaultUnchecked.trigger('change');
+		await inputCheckboxDefaultChecked.trigger('input');
+		await inputCheckboxDefaultUnchecked.trigger('input');
 		await nextTick();
 
 		// Assert new values

--- a/src/components/Form/form.spec.ts
+++ b/src/components/Form/form.spec.ts
@@ -288,4 +288,22 @@ describe('Form component', () => {
 		// Assert error message no longer present
 		expect(wrapper.find('.pdap-form-error-message').exists()).toBe(false);
 	});
+
+	test('Form waits to reset until resetOn prop switches to `true` and error is falsy', async () => {
+		const wrapper = mount(PdapForm, {
+			...base,
+			props: { ...base.props, error: 'foo', resetOn: false },
+		});
+
+		// Assert error state
+		expect(wrapper.find('.pdap-form-error-message').exists()).toBe(true);
+		// Assert error message
+		expect(wrapper.find('.pdap-form-error-message').text()).toBe('foo');
+
+		// Set values to correct values
+		await wrapper.setProps({ error: '', resetOn: true });
+
+		// Assert error message no longer present
+		expect(wrapper.find('.pdap-form-error-message').exists()).toBe(false);
+	});
 });

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -35,4 +35,5 @@ export interface PdapFormProps {
 	id: string;
 	name: string;
 	schema: PdapFormSchema;
+	resetOn: 'submit' | boolean;
 }

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -35,5 +35,5 @@ export interface PdapFormProps {
 	id: string;
 	name: string;
 	schema: PdapFormSchema;
-	resetOn: 'submit' | boolean;
+	resetOn?: 'submit' | boolean;
 }

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -37,7 +37,6 @@ const navLogoLinkIsPath = props.logoImageAnchorPath.startsWith('/');
 
 // Lifecycle methods
 onMounted(() => {
-	console.debug('on mounted');
 	getHeightAndSetToCSSVar();
 	window.addEventListener('resize', getHeightAndSetToCSSVar);
 });

--- a/src/components/Input/Checkbox/InputCheckbox.vue
+++ b/src/components/Input/Checkbox/InputCheckbox.vue
@@ -7,7 +7,7 @@
 		class="pdap-input-checkbox"
 		type="checkbox"
 		v-bind="$attrs"
-		@change="change"
+		@input="input"
 	/>
 </template>
 
@@ -18,10 +18,10 @@ defineProps<PdapInputCheckboxProps>();
 
 // Emits
 const emit = defineEmits<{
-	(event: 'change', val: Event): void;
+	(event: 'input', val: Event): void;
 }>();
 
-const change = (event: Event) => {
-	emit('change', event);
+const input = (event: Event) => {
+	emit('input', event);
 };
 </script>

--- a/src/components/Input/PdapInput.vue
+++ b/src/components/Input/PdapInput.vue
@@ -49,7 +49,7 @@ const errorMessageId = computed(() => `pdap-${props.name}-input-error`);
 @layer components {
 	/* General input styles  */
 	.pdap-input {
-		@apply h-[max-content] gap-4 leading-normal mb-3 w-full flex flex-col;
+		@apply h-[max-content] gap-1 leading-normal mb-3 w-full flex flex-col;
 	}
 
 	.pdap-input input {
@@ -78,7 +78,7 @@ const errorMessageId = computed(() => `pdap-${props.name}-input-error`);
 	}
 
 	.pdap-input-error label {
-		@apply justify-start text-sm;
+		@apply justify-start;
 	}
 
 	.pdap-input-error input {

--- a/src/components/Input/Text/InputText.vue
+++ b/src/components/Input/Text/InputText.vue
@@ -6,7 +6,6 @@
 		:placeholder="placeholder"
 		:value="value"
 		v-bind="$attrs"
-		@change="change"
 		@input="input"
 	/>
 </template>
@@ -18,13 +17,8 @@ defineProps<PdapInputTextProps>();
 
 // Emits
 const emit = defineEmits<{
-	(event: 'change', val: Event): void;
 	(event: 'input', val: Event): void;
 }>();
-
-const change = (event: Event) => {
-	emit('change', event);
-};
 
 const input = (event: Event) => {
 	emit('input', event);

--- a/src/demo/pages/ComponentDemo.vue
+++ b/src/demo/pages/ComponentDemo.vue
@@ -41,7 +41,7 @@
 			<div>
 				<h4>Or this:</h4>
 				<div
-					class="loading-shimmer h-48 bg-brand-gold flex flex-col justify-center items-center"
+					class="loading-shimmer h-48 bg-brand-gold flex flex-col justify-center items-center text-neutral-50"
 				>
 					<Spinner :show="true" text="Hello from the loading div" />
 				</div>
@@ -239,6 +239,7 @@ import { PdapDropdownTriggerType } from '../../components/Dropdown/types';
 
 const mockFormSchema = [
 	{
+		autocomplete: 'given-name',
 		id: 'first-name',
 		name: 'firstName',
 		label: 'What is your first name?',
@@ -252,6 +253,7 @@ const mockFormSchema = [
 		},
 	},
 	{
+		autocomplete: 'family-name',
 		id: 'last-name',
 		name: 'lastName',
 		label: 'What is your last name?',
@@ -339,7 +341,7 @@ function submit(values: Record<'firstName' | 'lastName' | 'iceCream', string>) {
 }
 
 function change(values: Record<'firstName' | 'lastName' | 'iceCream', string>) {
-	console.log('onChange', { values });
+	console.debug('onChange', { values });
 }
 
 onMounted(updateLoadingText);

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -1,9 +1,11 @@
 <template>
 	<main>
 		<Form
+			id="bar"
 			:error="error"
 			:schema="SCHEMA"
 			:reset-on="reset"
+			name="foo"
 			@submit="onSubmit"
 			@change="handleChangeOnError"
 		>
@@ -13,6 +15,7 @@
 </template>
 
 <script setup lang="ts">
+import { PdapInputTypes } from 'src/components/Input/types';
 import { Button, Form } from '../../components';
 import { ref } from 'vue';
 
@@ -23,7 +26,7 @@ const SCHEMA = [
 		id: 'email',
 		name: 'email',
 		label: 'Email',
-		type: 'text',
+		type: PdapInputTypes.TEXT,
 		placeholder: 'Your email address',
 		value: '',
 		validators: {
@@ -38,7 +41,7 @@ const SCHEMA = [
 		id: 'password',
 		name: 'password',
 		label: 'Password',
-		type: 'password',
+		type: PdapInputTypes.PASSWORD,
 		placeholder: 'Your password',
 		value: '',
 		validators: {
@@ -53,7 +56,7 @@ const SCHEMA = [
 		id: 'confirmPassword',
 		name: 'confirmPassword',
 		label: 'Confirm Password',
-		type: 'password',
+		type: PdapInputTypes.PASSWORD,
 		placeholder: 'Confirm your password',
 		value: '',
 		validators: {
@@ -65,13 +68,13 @@ const SCHEMA = [
 	},
 ];
 
-const error = ref(undefined);
+const error = ref<undefined | string>(undefined);
 const reset = ref(false);
 
 /**
  * When signing up: handles clearing pw-match form errors on change if they exist
  */
-function handleChangeOnError(formValues) {
+function handleChangeOnError(formValues: Record<string, string>) {
 	console.debug('onchange', { e: error.value, formValues: formValues.value });
 
 	if (error.value && formValues.password !== formValues.confirmPassword) {
@@ -83,7 +86,7 @@ function handleChangeOnError(formValues) {
  * When signing up: validates that passwords match
  * @returns {boolean} `false` if passwords do not match, `true` if they do
  */
-function handlePasswordValidation(formValues) {
+function handlePasswordValidation(formValues: Record<string, string>) {
 	console.debug('validate', { e: error.value });
 
 	if (formValues.password !== formValues.confirmPassword) {
@@ -100,7 +103,7 @@ function handlePasswordValidation(formValues) {
 /**
  * Logs user in or signs user up
  */
-function onSubmit(formValues) {
+function onSubmit(formValues: Record<string, string>) {
 	console.debug('onsubmit', { e: error.value });
 	if (!handlePasswordValidation(formValues)) {
 		return;

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -105,8 +105,7 @@ function onSubmit(formValues: Record<string, string>) {
 		return;
 	} else {
 		reset.value = true;
+		console.debug({ formValues });
 	}
-
-	console.debug({ formValues });
 }
 </script>

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { PdapInputTypes } from 'src/components/Input/types';
+import { PdapInputTypes } from '../../components/Input/types';
 import { Button, Form } from '../../components';
 import { ref } from 'vue';
 

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -22,6 +22,7 @@ import { ref } from 'vue';
 // Constants
 const SCHEMA = [
 	{
+		autocomplete: 'home email',
 		'data-test': 'email',
 		id: 'email',
 		name: 'email',
@@ -37,6 +38,7 @@ const SCHEMA = [
 		},
 	},
 	{
+		autocomplete: 'current-password',
 		'data-test': 'password',
 		id: 'password',
 		name: 'password',
@@ -52,6 +54,7 @@ const SCHEMA = [
 		},
 	},
 	{
+		autocomplete: 'current-password',
 		'data-test': 'confirm-password',
 		id: 'confirmPassword',
 		name: 'confirmPassword',

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -48,7 +48,7 @@ const SCHEMA = [
 		value: '',
 		validators: {
 			password: {
-				message: 'Please provide your password',
+				message: 'Please provide a valid password',
 				value: true,
 			},
 		},
@@ -64,7 +64,7 @@ const SCHEMA = [
 		value: '',
 		validators: {
 			password: {
-				message: 'Please confirm your password',
+				message: 'Please confirm your valid password',
 				value: true,
 			},
 		},

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -1,0 +1,113 @@
+<template>
+	<main>
+		<Form
+			:error="error"
+			:schema="SCHEMA"
+			:reset-on="reset"
+			@submit="onSubmit"
+			@change="handleChangeOnError"
+		>
+			<Button type="submit">Submit</Button>
+		</Form>
+	</main>
+</template>
+
+<script setup lang="ts">
+import { Button, Form } from '../../components';
+import { ref } from 'vue';
+
+// Constants
+const SCHEMA = [
+	{
+		'data-test': 'email',
+		id: 'email',
+		name: 'email',
+		label: 'Email',
+		type: 'text',
+		placeholder: 'Your email address',
+		value: '',
+		validators: {
+			email: {
+				message: 'Please provide your email address',
+				value: true,
+			},
+		},
+	},
+	{
+		'data-test': 'password',
+		id: 'password',
+		name: 'password',
+		label: 'Password',
+		type: 'password',
+		placeholder: 'Your password',
+		value: '',
+		validators: {
+			password: {
+				message: 'Please provide your password',
+				value: true,
+			},
+		},
+	},
+	{
+		'data-test': 'confirm-password',
+		id: 'confirmPassword',
+		name: 'confirmPassword',
+		label: 'Confirm Password',
+		type: 'password',
+		placeholder: 'Confirm your password',
+		value: '',
+		validators: {
+			password: {
+				message: 'Please confirm your password',
+				value: true,
+			},
+		},
+	},
+];
+
+const error = ref(undefined);
+const reset = ref(false);
+
+/**
+ * When signing up: handles clearing pw-match form errors on change if they exist
+ */
+function handleChangeOnError(formValues) {
+	console.debug('onchange', { e: error.value, formValues: formValues.value });
+
+	if (error.value && formValues.password !== formValues.confirmPassword) {
+		handlePasswordValidation(formValues);
+	}
+}
+
+/**
+ * When signing up: validates that passwords match
+ * @returns {boolean} `false` if passwords do not match, `true` if they do
+ */
+function handlePasswordValidation(formValues) {
+	console.debug('validate', { e: error.value });
+
+	if (formValues.password !== formValues.confirmPassword) {
+		if (!error.value) {
+			error.value = 'Passwords do not match, please try again.';
+		}
+		return false;
+	} else {
+		error.value = undefined;
+		return true;
+	}
+}
+
+/**
+ * Logs user in or signs user up
+ */
+function onSubmit(formValues) {
+	console.debug('onsubmit', { e: error.value });
+	if (!handlePasswordValidation(formValues)) {
+		return;
+	} else {
+		reset.value = true;
+	}
+
+	console.debug({ formValues });
+}
+</script>

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -7,7 +7,7 @@
 			:reset-on="reset"
 			name="foo"
 			@submit="onSubmit"
-			@change="handleChangeOnError"
+			@change="handleChange"
 		>
 			<Button type="submit">Submit</Button>
 		</Form>
@@ -74,10 +74,8 @@ const reset = ref(false);
 /**
  * When signing up: handles clearing pw-match form errors on change if they exist
  */
-function handleChangeOnError(formValues: Record<string, string>) {
-	console.debug('onchange', { e: error.value, formValues: formValues.value });
-
-	if (error.value && formValues.password !== formValues.confirmPassword) {
+function handleChange(formValues: Record<string, string>) {
+	if (error.value) {
 		handlePasswordValidation(formValues);
 	}
 }
@@ -87,8 +85,6 @@ function handleChangeOnError(formValues: Record<string, string>) {
  * @returns {boolean} `false` if passwords do not match, `true` if they do
  */
 function handlePasswordValidation(formValues: Record<string, string>) {
-	console.debug('validate', { e: error.value });
-
 	if (formValues.password !== formValues.confirmPassword) {
 		if (!error.value) {
 			error.value = 'Passwords do not match, please try again.';
@@ -104,7 +100,6 @@ function handlePasswordValidation(formValues: Record<string, string>) {
  * Logs user in or signs user up
  */
 function onSubmit(formValues: Record<string, string>) {
-	console.debug('onsubmit', { e: error.value });
 	if (!handlePasswordValidation(formValues)) {
 		return;
 	} else {

--- a/src/demo/pages/SignupFormDemo.vue
+++ b/src/demo/pages/SignupFormDemo.vue
@@ -101,6 +101,7 @@ function handlePasswordValidation(formValues: Record<string, string>) {
  */
 function onSubmit(formValues: Record<string, string>) {
 	if (!handlePasswordValidation(formValues)) {
+		reset.value = false;
 		return;
 	} else {
 		reset.value = true;

--- a/src/demo/router.js
+++ b/src/demo/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import ComponentDemo from './pages/ComponentDemo.vue';
+import SignupFormDemo from './pages/SignupFormDemo.vue';
 
 const routes = [
 	{
@@ -39,6 +40,11 @@ const routes = [
 				],
 			},
 		],
+	},
+	{
+		path: '/sign-up-demo',
+		component: SignupFormDemo,
+		name: 'Login Demo',
 	},
 ];
 


### PR DESCRIPTION
## Background
See #58 

Sometimes we will want to do custom validation on form submission. (See the login / signin form in `data-sources`). When this happens, the UX will be better if we preserve the current input values for the user, rather than clearing them on every form submission automatically.

## Description
- Adds new prop `resetOn` to `Form` of type `'submit' | boolean`. If `'submit'` is passed, the form clears on submission. If `boolean` is passed, the form only resets when the `resetOn` prop changes to `true`.
- Updates `Form` tests
- Updates documentation

## To test
1. Run the demo app, navigate to `localhost:8888/sign-up-demo`
2. Add a valid password in each box, but mis-matched (i.e. `Password1!` and `Password2!`
3. Ensure that on form submission, you are presented with an error, but the form input values persist.
4. Correct the mis-match
5. Click the submit button, ensure that the form data you entered is logged to the console (it's a debug log, so you may have to turn those on in your browser).