### PR TITLE
feat(new-default-font): public sans

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@100..900&display=swap" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vite + Vue + TS</title>
 </head>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,6 +40,7 @@ export const tailwindConfig = {
 		// Using properties directly - overrides tailwind theme defaults for entire section
 		fontFamily: {
 			sans: [
+				'"Public Sans"',
 				'"Libre Franklin"',
 				'ui-sans-serif',
 				'system-ui',


### PR DESCRIPTION
### Fixes

Nothing! I am just a nerd about fonts/type and I just found out about Public Sans, which is based on Libre Franklin, but much improved and generally feature-packed: https://github.com/uswds/public-sans

Franklin is still a gorgeous, historic font for print; if we ever print anything, we can use it.

### Contents

- adds Public Sans to the top of the list as a default; retains Libre Franklin 
- adds the `fonts.googleapis` embed to index.html, I was seeing a system font

### To do

- In order for this change to take effect, the `<head>` of the `index.html` of anything we want to update will need to change, as well as bumping the design system version.
  - graceful: adding a `fonts.googleapis` embed for Public Sans, and leaving the Libre Franklin one. That way, no matter which version of the design system is used, one of those two fonts will be used (user settings notwithstanding)
  - less graceful: swapping them out to cut down on page load, and making sure a recent version of the design system is used (part of why I wanted to update both `main` and `beta` just to get this over with, unless that makes things needlessly complicated)

### Docs/related

- I mentioned this in the `brand assets`:

<img width="766" alt="Screen Shot 2024-07-09 at 2 02 01 PM" src="https://github.com/Police-Data-Accessibility-Project/design-system/assets/30379833/06345e2c-5ae3-40ff-9de3-9b14b866719d">
