### PR TITLE
fix: visual tweaks

### DIFF
--- a/src/components/ErrorBoundary/PdapErrorBoundary.vue
+++ b/src/components/ErrorBoundary/PdapErrorBoundary.vue
@@ -66,11 +66,11 @@ onErrorCaptured((err, vm, info) => {
  *
  * <template>
  * 	<AuthWrapper>
- * 		<Header :logo-image-src="lockup" />
+ * 		<Header />
  * 		<ErrorBoundary component="main">
  * 			<router-view />
  * 		</ErrorBoundary>
- * 		<Footer :logo-image-src="acronym" />
+ * 		<Footer />
  * 	</AuthWrapper>
  * </template>
  *

--- a/src/components/ErrorBoundary/README.md
+++ b/src/components/ErrorBoundary/README.md
@@ -14,11 +14,11 @@ _From data-sources `App.vue`: This will catch any uncaught error at the route le
 ```
 <template>
 	<AuthWrapper>
-		<Header :logo-image-src="lockup" />
+		<Header />
 		<ErrorBoundary component="main">
 			<router-view />
 		</ErrorBoundary>
-		<Footer :logo-image-src="acronym" />
+		<Footer />
 	</AuthWrapper>
 </template>
 ```

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -14,14 +14,14 @@
 					rel="noreferrer"
 					class="text-neutral-50 dark:text-neutral-950"
 				>
-					<FontAwesomeIcon v-if="link.icon" :icon="iconMap.get(link.icon)!" />
+					<FontAwesomeIcon v-if="link.icon" :icon="iconMap.get(link.icon)!" class="text-brand-wine-100 dark:text-brand-wine-800"/>
 					{{ link.text }}
 				</a>
 				<router-link
 					v-if="link.path"
 					active-class="pdap-footer-social-link-current"
 					exact-active-class="pdap-footer-social-link-current-exact"
-					class="pdap-footer-social-link text-neutral-50 dark:text-neutral-950"
+					class="pdap-footer-social-link text-wineneutral-50 dark:text-wineneutral-950"
 					:to="link.path"
 				>
 					<FontAwesomeIcon v-if="link.icon" :icon="iconMap.get(link.icon)!" />

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -1,7 +1,6 @@
 <template>
 	<footer
-		class="bg-brand-wine text-neutral-50 dark:text-neutral-950 flex flex-col lg:flex-row gap-4 xl:gap-12 p-6 lg:p-4 relative lg:sticky lg:bottom-0 text-med xl:text-xl"
-		:style="{ '--fundraising-progress': `${targetProgress}%` }"
+		class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 lg:p-2 lg:px-8 relative lg:sticky lg:bottom-0 text-med xl:text-xl"
 	>
 		<!-- LINKS -->
 		<ul
@@ -29,45 +28,8 @@
 					{{ link.text }}
 				</router-link>
 			</li>
-		</ul>
-
-		<!-- FUNDRAISING METER -->
-		<div v-if="fundraisingData.goal > 0">
-			<span class="flex gap-1">
-				<a
-					href="https://pdap.io/donate"
-					target="_blank"
-					rel="noreferrer"
-					class="text-neutral-50 dark:text-neutral-950"
-				>
-					<span><FontAwesomeIcon :icon="faCircleDollarToSlot" /> Donate</span>
-					(${{ formatWithCommas(fundraisingData.raised) }} of ${{
-						formatWithCommas(fundraisingData.goal)
-					}}
-					raised
-					<span
-						v-if="
-							fundraisingData.goal > 0 &&
-							fundraisingData.raised === fundraisingData.goal
-						"
-					>
-						🎉🎉🎉
-					</span>
-					)
-				</a>
-			</span>
-
-			<span
-				class="inline-block bg-neutral-50 dark:bg-neutral-950 h-3 w-full rounded-full relative before:inline-block before:h-full before:bg-brand-gold before:absolute before:rounded-l-full before:transition-[width] before:duration-1000 before:ease-out before:w-[var(--fundraising-progress)]"
-				:class="{
-					'before:rounded-r-full':
-						fundraisingData.raised === fundraisingData.goal,
-				}"
-			/>
-		</div>
-
-		<!-- COPYRIGHT AND TRANSPARENCY -->
-		<div class="flex gap-4 justify-between lg:justify-start lg:ml-auto">
+		</ul><!-- COPYRIGHT AND TRANSPARENCY -->
+		<div class="flex gap-4 justify-between text-lg lg:justify-start lg:items-center lg:ml-auto">
 			<p class="lg:max-w-[325px] lg:text-right xl:max-w-[375px]">
 				© {{ new Date().getFullYear() }} Police Data Accessibility Project is a
 				non-profit. EIN: 85-4207132.
@@ -90,11 +52,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from 'vue';
+import { inject } from 'vue';
 import {
 	PdapFooterSocialLinks,
 	FooterIconName,
-	PdapFooterProps,
 } from './types';
 import { FOOTER_LINK_ICONS } from './constants';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -107,12 +68,8 @@ import {
 	faSmile,
 	faInbox,
 	faBook,
-	faCircleDollarToSlot,
 	faEnvelope,
 } from '@fortawesome/free-solid-svg-icons';
-import { formatWithCommas } from '../../utils/format';
-
-const props = defineProps<PdapFooterProps>();
 
 const iconMap = new Map<FooterIconName, IconDefinition>([
 	[FOOTER_LINK_ICONS.GITHUB, faGithub],
@@ -155,20 +112,6 @@ const links = inject<PdapFooterSocialLinks[]>('footerLinks', [
 		icon: FOOTER_LINK_ICONS.EMAIL,
 	},
 ]);
-
-const targetProgress = computed(() => {
-	let progress = 2;
-
-	if (!props.fundraisingData) return (progress = 0);
-
-	const ratio = props.fundraisingData.raised / props.fundraisingData.goal;
-
-	if (ratio > 0.02) {
-		progress = ratio * 100;
-	}
-
-	return Math.ceil(progress);
-});
 </script>
 
 <script lang="ts">

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -17,7 +17,7 @@
 					<FontAwesomeIcon
 						v-if="link.icon"
 						:icon="iconMap.get(link.icon)!"
-						class="text-brand-wine-100 dark:text-brand-wine-800"
+						class="text-brand-wine-100"
 					/>
 					{{ link.text }}
 				</a>

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -14,7 +14,11 @@
 					rel="noreferrer"
 					class="text-neutral-50 dark:text-neutral-950"
 				>
-					<FontAwesomeIcon v-if="link.icon" :icon="iconMap.get(link.icon)!" class="text-brand-wine-100 dark:text-brand-wine-800"/>
+					<FontAwesomeIcon
+						v-if="link.icon"
+						:icon="iconMap.get(link.icon)!"
+						class="text-brand-wine-100 dark:text-brand-wine-800"
+					/>
 					{{ link.text }}
 				</a>
 				<router-link
@@ -28,8 +32,11 @@
 					{{ link.text }}
 				</router-link>
 			</li>
-		</ul><!-- COPYRIGHT AND TRANSPARENCY -->
-		<div class="flex gap-4 justify-between text-lg lg:justify-start lg:items-center lg:ml-auto">
+		</ul>
+		<!-- COPYRIGHT AND TRANSPARENCY -->
+		<div
+			class="flex gap-4 justify-between text-lg lg:justify-start lg:items-center lg:ml-auto"
+		>
 			<p class="lg:max-w-[325px] lg:text-right xl:max-w-[375px]">
 				© {{ new Date().getFullYear() }} Police Data Accessibility Project is a
 				non-profit. EIN: 85-4207132.
@@ -53,10 +60,7 @@
 
 <script setup lang="ts">
 import { inject } from 'vue';
-import {
-	PdapFooterSocialLinks,
-	FooterIconName,
-} from './types';
+import { PdapFooterSocialLinks, FooterIconName } from './types';
 import { FOOTER_LINK_ICONS } from './constants';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -101,7 +101,6 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
 	faGithub,
 	faDiscord,
-	faLinkedin,
 	IconDefinition,
 } from '@fortawesome/free-brands-svg-icons';
 import {
@@ -109,6 +108,7 @@ import {
 	faInbox,
 	faBook,
 	faCircleDollarToSlot,
+	faEnvelope,
 } from '@fortawesome/free-solid-svg-icons';
 import { formatWithCommas } from '../../utils/format';
 
@@ -117,7 +117,7 @@ const props = defineProps<PdapFooterProps>();
 const iconMap = new Map<FooterIconName, IconDefinition>([
 	[FOOTER_LINK_ICONS.GITHUB, faGithub],
 	[FOOTER_LINK_ICONS.DISCORD, faDiscord],
-	[FOOTER_LINK_ICONS.LINKEDIN, faLinkedin],
+	[FOOTER_LINK_ICONS.EMAIL, faEnvelope],
 	[FOOTER_LINK_ICONS.JOBS, faSmile],
 	[FOOTER_LINK_ICONS.NEWSLETTER, faInbox],
 	[FOOTER_LINK_ICONS.DOCS, faBook],
@@ -135,11 +135,6 @@ const links = inject<PdapFooterSocialLinks[]>('footerLinks', [
 		icon: FOOTER_LINK_ICONS.DISCORD,
 	},
 	{
-		href: 'https://www.linkedin.com/company/pdap',
-		text: 'LinkedIn',
-		icon: FOOTER_LINK_ICONS.LINKEDIN,
-	},
-	{
 		href: 'https://pdap.io/jobs',
 		text: 'Jobs',
 		icon: FOOTER_LINK_ICONS.JOBS,
@@ -153,6 +148,11 @@ const links = inject<PdapFooterSocialLinks[]>('footerLinks', [
 		href: 'https://docs.pdap.io/',
 		text: 'Docs',
 		icon: FOOTER_LINK_ICONS.DOCS,
+	},
+	{
+		href: 'mailto:contact@pdap.io',
+		text: 'Email',
+		icon: FOOTER_LINK_ICONS.EMAIL,
 	},
 ]);
 

--- a/src/components/Footer/README.md
+++ b/src/components/Footer/README.md
@@ -1,11 +1,5 @@
 # Footer
 
-## Props
-
-| name              | required? | types                              | description                  | default |
-| ----------------- | --------- | ---------------------------------- | ---------------------------- | ------- |
-| `fundraisingData` | yes       | `{ raised: string; goal: string }` | data from donor box campaign |         |
-
 ## Notes
 
 The `Footer` component provides support for overriding the default social links. The `links` variable is `inject`ed by the component, using the following defaults:

--- a/src/components/Footer/README.md
+++ b/src/components/Footer/README.md
@@ -27,11 +27,6 @@ export default {
             icon: FOOTER_LINK_ICONS.DISCORD,
           },
           {
-            href: 'https://www.linkedin.com/company/pdap',
-            text: 'LinkedIn',
-            icon: FOOTER_LINK_ICONS.LINKEDIN,
-          },
-          {
             href: 'https://pdap.io/jobs',
             text: 'Jobs',
             icon: FOOTER_LINK_ICONS.JOBS,
@@ -45,6 +40,11 @@ export default {
             href: 'https://docs.pdap.io/',
             text: 'Docs',
             icon: FOOTER_LINK_ICONS.DOCS,
+          },
+          {
+            href: 'mailto:contact@pdap.io',
+            text: 'Email',
+            icon: FOOTER_LINK_ICONS.EMAIL,
           },
       ]
     }

--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -21,14 +21,6 @@ exports[`Footer component > Renders a footer 1`] = `
       <!--v-if-->
     </li>
     <li class="w-max">
-      <a class="text-neutral-50 dark:text-neutral-950" href="https://www.linkedin.com/company/pdap" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-linkedin" data-icon="linkedin" data-prefix="fab" focusable="false" role="img" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg">
-          <path class="" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z" fill="currentColor" />
-        </svg> LinkedIn
-      </a>
-      <!--v-if-->
-    </li>
-    <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://pdap.io/jobs" rel="noreferrer" target="_blank">
         <svg aria-hidden="true" class="svg-inline--fa fa-face-smile" data-icon="face-smile" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM164.1 325.5C182 346.2 212.6 368 256 368s74-21.8 91.9-42.5c5.8-6.7 15.9-7.4 22.6-1.6s7.4 15.9 1.6 22.6C349.8 372.1 311.1 400 256 400s-93.8-27.9-116.1-53.5c-5.8-6.7-5.1-16.8 1.6-22.6s16.8-5.1 22.6 1.6zM144.4 208a32 32 0 1 1 64 0 32 32 0 1 1 -64 0zm192-32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" fill="currentColor" />
@@ -49,6 +41,14 @@ exports[`Footer component > Renders a footer 1`] = `
         <svg aria-hidden="true" class="svg-inline--fa fa-book" data-icon="book" data-prefix="fas" focusable="false" role="img" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M96 0C43 0 0 43 0 96L0 416c0 53 43 96 96 96l288 0 32 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l0-64c17.7 0 32-14.3 32-32l0-320c0-17.7-14.3-32-32-32L384 0 96 0zm0 384l256 0 0 64L96 448c-17.7 0-32-14.3-32-32s14.3-32 32-32zm32-240c0-8.8 7.2-16 16-16l192 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-192 0c-8.8 0-16-7.2-16-16zm16 48l192 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-192 0c-8.8 0-16-7.2-16-16s7.2-16 16-16z" fill="currentColor" />
         </svg> Docs
+      </a>
+      <!--v-if-->
+    </li>
+    <li class="w-max">
+      <a class="text-neutral-50 dark:text-neutral-950" href="mailto:contact@pdap.io" rel="noreferrer" target="_blank">
+        <svg aria-hidden="true" class="svg-inline--fa fa-envelope" data-icon="envelope" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+          <path class="" d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48L48 64zM0 176L0 384c0 35.3 28.7 64 64 64l384 0c35.3 0 64-28.7 64-64l0-208L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z" fill="currentColor" />
+        </svg> Email
       </a>
       <!--v-if-->
     </li>

--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Footer component > Renders a footer 1`] = `
   <ul class="grid grid-cols-2 gap-2 md:grid-cols-[auto_auto_auto] lg:w-max lg:gap-x-3 xl:gap-x-4">
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://github.com/orgs/Police-Data-Accessibility-Project" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-github text-brand-wine-100 dark:text-brand-wine-800" data-icon="github" data-prefix="fab" focusable="false" role="img" viewBox="0 0 496 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-github text-brand-wine-100" data-icon="github" data-prefix="fab" focusable="false" role="img" viewBox="0 0 496 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" fill="currentColor" />
         </svg> Github
       </a>
@@ -14,7 +14,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://discord.gg/wMqex8nKZJ" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-discord text-brand-wine-100 dark:text-brand-wine-800" data-icon="discord" data-prefix="fab" focusable="false" role="img" viewBox="0 0 640 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-discord text-brand-wine-100" data-icon="discord" data-prefix="fab" focusable="false" role="img" viewBox="0 0 640 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M524.531,69.836a1.5,1.5,0,0,0-.764-.7A485.065,485.065,0,0,0,404.081,32.03a1.816,1.816,0,0,0-1.923.91,337.461,337.461,0,0,0-14.9,30.6,447.848,447.848,0,0,0-134.426,0,309.541,309.541,0,0,0-15.135-30.6,1.89,1.89,0,0,0-1.924-.91A483.689,483.689,0,0,0,116.085,69.137a1.712,1.712,0,0,0-.788.676C39.068,183.651,18.186,294.69,28.43,404.354a2.016,2.016,0,0,0,.765,1.375A487.666,487.666,0,0,0,176.02,479.918a1.9,1.9,0,0,0,2.063-.676A348.2,348.2,0,0,0,208.12,430.4a1.86,1.86,0,0,0-1.019-2.588,321.173,321.173,0,0,1-45.868-21.853,1.885,1.885,0,0,1-.185-3.126c3.082-2.309,6.166-4.711,9.109-7.137a1.819,1.819,0,0,1,1.9-.256c96.229,43.917,200.41,43.917,295.5,0a1.812,1.812,0,0,1,1.924.233c2.944,2.426,6.027,4.851,9.132,7.16a1.884,1.884,0,0,1-.162,3.126,301.407,301.407,0,0,1-45.89,21.83,1.875,1.875,0,0,0-1,2.611,391.055,391.055,0,0,0,30.014,48.815,1.864,1.864,0,0,0,2.063.7A486.048,486.048,0,0,0,610.7,405.729a1.882,1.882,0,0,0,.765-1.352C623.729,277.594,590.933,167.465,524.531,69.836ZM222.491,337.58c-28.972,0-52.844-26.587-52.844-59.239S193.056,219.1,222.491,219.1c29.665,0,53.306,26.82,52.843,59.239C275.334,310.993,251.924,337.58,222.491,337.58Zm195.38,0c-28.971,0-52.843-26.587-52.843-59.239S388.437,219.1,417.871,219.1c29.667,0,53.307,26.82,52.844,59.239C470.715,310.993,447.538,337.58,417.871,337.58Z" fill="currentColor" />
         </svg> Discord
       </a>
@@ -22,7 +22,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://pdap.io/jobs" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-face-smile text-brand-wine-100 dark:text-brand-wine-800" data-icon="face-smile" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-face-smile text-brand-wine-100" data-icon="face-smile" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM164.1 325.5C182 346.2 212.6 368 256 368s74-21.8 91.9-42.5c5.8-6.7 15.9-7.4 22.6-1.6s7.4 15.9 1.6 22.6C349.8 372.1 311.1 400 256 400s-93.8-27.9-116.1-53.5c-5.8-6.7-5.1-16.8 1.6-22.6s16.8-5.1 22.6 1.6zM144.4 208a32 32 0 1 1 64 0 32 32 0 1 1 -64 0zm192-32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" fill="currentColor" />
         </svg> Jobs
       </a>
@@ -30,7 +30,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://newsletter.pdap.io/" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-inbox text-brand-wine-100 dark:text-brand-wine-800" data-icon="inbox" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-inbox text-brand-wine-100" data-icon="inbox" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M121 32C91.6 32 66 52 58.9 80.5L1.9 308.4C.6 313.5 0 318.7 0 323.9L0 416c0 35.3 28.7 64 64 64l384 0c35.3 0 64-28.7 64-64l0-92.1c0-5.2-.6-10.4-1.9-15.5l-57-227.9C446 52 420.4 32 391 32L121 32zm0 64l270 0 48 192-51.2 0c-12.1 0-23.2 6.8-28.6 17.7l-14.3 28.6c-5.4 10.8-16.5 17.7-28.6 17.7l-120.4 0c-12.1 0-23.2-6.8-28.6-17.7l-14.3-28.6c-5.4-10.8-16.5-17.7-28.6-17.7L73 288 121 96z" fill="currentColor" />
         </svg> Newsletter
       </a>
@@ -38,7 +38,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://docs.pdap.io/" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-book text-brand-wine-100 dark:text-brand-wine-800" data-icon="book" data-prefix="fas" focusable="false" role="img" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-book text-brand-wine-100" data-icon="book" data-prefix="fas" focusable="false" role="img" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M96 0C43 0 0 43 0 96L0 416c0 53 43 96 96 96l288 0 32 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l0-64c17.7 0 32-14.3 32-32l0-320c0-17.7-14.3-32-32-32L384 0 96 0zm0 384l256 0 0 64L96 448c-17.7 0-32-14.3-32-32s14.3-32 32-32zm32-240c0-8.8 7.2-16 16-16l192 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-192 0c-8.8 0-16-7.2-16-16zm16 48l192 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-192 0c-8.8 0-16-7.2-16-16s7.2-16 16-16z" fill="currentColor" />
         </svg> Docs
       </a>
@@ -46,7 +46,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="mailto:contact@pdap.io" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-envelope text-brand-wine-100 dark:text-brand-wine-800" data-icon="envelope" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-envelope text-brand-wine-100" data-icon="envelope" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48L48 64zM0 176L0 384c0 35.3 28.7 64 64 64l384 0c35.3 0 64-28.7 64-64l0-208L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z" fill="currentColor" />
         </svg> Email
       </a>

--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Footer component > Renders a footer 1`] = `
-<footer class="bg-brand-wine text-neutral-50 dark:text-neutral-950 flex flex-col lg:flex-row gap-4 xl:gap-12 p-6 lg:p-4 relative lg:sticky lg:bottom-0 text-med xl:text-xl" style="--fundraising-progress: 50%;">
+<footer class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 lg:p-2 lg:px-8 relative lg:sticky lg:bottom-0 text-med xl:text-xl">
   <!-- LINKS -->
   <ul class="grid grid-cols-2 gap-2 md:grid-cols-[auto_auto_auto] lg:w-max lg:gap-x-3 xl:gap-x-4">
     <li class="w-max">
@@ -52,21 +52,8 @@ exports[`Footer component > Renders a footer 1`] = `
       </a>
       <!--v-if-->
     </li>
-  </ul><!-- FUNDRAISING METER -->
-  <div>
-    <span class="flex gap-1">
-      <a class="text-neutral-50 dark:text-neutral-950" href="https://pdap.io/donate" rel="noreferrer" target="_blank">
-        <span>
-          <svg aria-hidden="true" class="svg-inline--fa fa-circle-dollar-to-slot" data-icon="circle-dollar-to-slot" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-            <path class="" d="M326.7 403.7c-22.1 8-45.9 12.3-70.7 12.3s-48.7-4.4-70.7-12.3l-.8-.3c-30-11-56.8-28.7-78.6-51.4C70 314.6 48 263.9 48 208C48 93.1 141.1 0 256 0S464 93.1 464 208c0 55.9-22 106.6-57.9 144c-1 1-2 2.1-3 3.1c-21.4 21.4-47.4 38.1-76.3 48.6zM256 91.9c-11.1 0-20.1 9-20.1 20.1l0 6c-5.6 1.2-10.9 2.9-15.9 5.1c-15 6.8-27.9 19.4-31.1 37.7c-1.8 10.2-.8 20 3.4 29c4.2 8.8 10.7 15 17.3 19.5c11.6 7.9 26.9 12.5 38.6 16l2.2 .7c13.9 4.2 23.4 7.4 29.3 11.7c2.5 1.8 3.4 3.2 3.7 4c.3 .8 .9 2.6 .2 6.7c-.6 3.5-2.5 6.4-8 8.8c-6.1 2.6-16 3.9-28.8 1.9c-6-1-16.7-4.6-26.2-7.9c0 0 0 0 0 0s0 0 0 0s0 0 0 0c-2.2-.7-4.3-1.5-6.4-2.1c-10.5-3.5-21.8 2.2-25.3 12.7s2.2 21.8 12.7 25.3c1.2 .4 2.7 .9 4.4 1.5c7.9 2.7 20.3 6.9 29.8 9.1l0 6.4c0 11.1 9 20.1 20.1 20.1s20.1-9 20.1-20.1l0-5.5c5.3-1 10.5-2.5 15.4-4.6c15.7-6.7 28.4-19.7 31.6-38.7c1.8-10.4 1-20.3-3-29.4c-3.9-9-10.2-15.6-16.9-20.5c-12.2-8.8-28.3-13.7-40.4-17.4l-.8-.2c-14.2-4.3-23.8-7.3-29.9-11.4c-2.6-1.8-3.4-3-3.6-3.5c-.2-.3-.7-1.6-.1-5c.3-1.9 1.9-5.2 8.2-8.1c6.4-2.9 16.4-4.5 28.6-2.6c4.3 .7 17.9 3.3 21.7 4.3c10.7 2.8 21.6-3.5 24.5-14.2s-3.5-21.6-14.2-24.5c-4.4-1.2-14.4-3.2-21-4.4l0-6.3c0-11.1-9-20.1-20.1-20.1zM48 352l16 0c19.5 25.9 44 47.7 72.2 64L64 416l0 32 192 0 192 0 0-32-72.2 0c28.2-16.3 52.8-38.1 72.2-64l16 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48L48 512c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48z" fill="currentColor" />
-          </svg> Donate
-        </span> ($5,000 of $10,000 raised
-        <!--v-if--> )
-      </a>
-    </span>
-    <span class="inline-block bg-neutral-50 dark:bg-neutral-950 h-3 w-full rounded-full relative before:inline-block before:h-full before:bg-brand-gold before:absolute before:rounded-l-full before:transition-[width] before:duration-1000 before:ease-out before:w-[var(--fundraising-progress)]"></span>
-  </div><!-- COPYRIGHT AND TRANSPARENCY -->
-  <div class="flex gap-4 justify-between lg:justify-start lg:ml-auto">
+  </ul><!-- COPYRIGHT AND TRANSPARENCY -->
+  <div class="flex gap-4 justify-between text-lg lg:justify-start lg:items-center lg:ml-auto">
     <p class="lg:max-w-[325px] lg:text-right xl:max-w-[375px]"> © 2025 Police Data Accessibility Project is a non-profit. EIN: 85-4207132. </p><!-- Widget / logo links -->
     <a href="https://www.guidestar.org/profile/85-4207132" rel="noreferrer" target="_blank">
       <img alt="platinum transparency" class="w-14 h-14" src="https://widgets.guidestar.org/gximage2?o=9973356&amp;l=v4">

--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Footer component > Renders a footer 1`] = `
   <ul class="grid grid-cols-2 gap-2 md:grid-cols-[auto_auto_auto] lg:w-max lg:gap-x-3 xl:gap-x-4">
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://github.com/orgs/Police-Data-Accessibility-Project" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-github" data-icon="github" data-prefix="fab" focusable="false" role="img" viewBox="0 0 496 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-github text-brand-wine-100 dark:text-brand-wine-800" data-icon="github" data-prefix="fab" focusable="false" role="img" viewBox="0 0 496 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" fill="currentColor" />
         </svg> Github
       </a>
@@ -14,7 +14,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://discord.gg/wMqex8nKZJ" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-discord" data-icon="discord" data-prefix="fab" focusable="false" role="img" viewBox="0 0 640 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-discord text-brand-wine-100 dark:text-brand-wine-800" data-icon="discord" data-prefix="fab" focusable="false" role="img" viewBox="0 0 640 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M524.531,69.836a1.5,1.5,0,0,0-.764-.7A485.065,485.065,0,0,0,404.081,32.03a1.816,1.816,0,0,0-1.923.91,337.461,337.461,0,0,0-14.9,30.6,447.848,447.848,0,0,0-134.426,0,309.541,309.541,0,0,0-15.135-30.6,1.89,1.89,0,0,0-1.924-.91A483.689,483.689,0,0,0,116.085,69.137a1.712,1.712,0,0,0-.788.676C39.068,183.651,18.186,294.69,28.43,404.354a2.016,2.016,0,0,0,.765,1.375A487.666,487.666,0,0,0,176.02,479.918a1.9,1.9,0,0,0,2.063-.676A348.2,348.2,0,0,0,208.12,430.4a1.86,1.86,0,0,0-1.019-2.588,321.173,321.173,0,0,1-45.868-21.853,1.885,1.885,0,0,1-.185-3.126c3.082-2.309,6.166-4.711,9.109-7.137a1.819,1.819,0,0,1,1.9-.256c96.229,43.917,200.41,43.917,295.5,0a1.812,1.812,0,0,1,1.924.233c2.944,2.426,6.027,4.851,9.132,7.16a1.884,1.884,0,0,1-.162,3.126,301.407,301.407,0,0,1-45.89,21.83,1.875,1.875,0,0,0-1,2.611,391.055,391.055,0,0,0,30.014,48.815,1.864,1.864,0,0,0,2.063.7A486.048,486.048,0,0,0,610.7,405.729a1.882,1.882,0,0,0,.765-1.352C623.729,277.594,590.933,167.465,524.531,69.836ZM222.491,337.58c-28.972,0-52.844-26.587-52.844-59.239S193.056,219.1,222.491,219.1c29.665,0,53.306,26.82,52.843,59.239C275.334,310.993,251.924,337.58,222.491,337.58Zm195.38,0c-28.971,0-52.843-26.587-52.843-59.239S388.437,219.1,417.871,219.1c29.667,0,53.307,26.82,52.844,59.239C470.715,310.993,447.538,337.58,417.871,337.58Z" fill="currentColor" />
         </svg> Discord
       </a>
@@ -22,7 +22,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://pdap.io/jobs" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-face-smile" data-icon="face-smile" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-face-smile text-brand-wine-100 dark:text-brand-wine-800" data-icon="face-smile" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM164.1 325.5C182 346.2 212.6 368 256 368s74-21.8 91.9-42.5c5.8-6.7 15.9-7.4 22.6-1.6s7.4 15.9 1.6 22.6C349.8 372.1 311.1 400 256 400s-93.8-27.9-116.1-53.5c-5.8-6.7-5.1-16.8 1.6-22.6s16.8-5.1 22.6 1.6zM144.4 208a32 32 0 1 1 64 0 32 32 0 1 1 -64 0zm192-32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" fill="currentColor" />
         </svg> Jobs
       </a>
@@ -30,7 +30,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://newsletter.pdap.io/" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-inbox" data-icon="inbox" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-inbox text-brand-wine-100 dark:text-brand-wine-800" data-icon="inbox" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M121 32C91.6 32 66 52 58.9 80.5L1.9 308.4C.6 313.5 0 318.7 0 323.9L0 416c0 35.3 28.7 64 64 64l384 0c35.3 0 64-28.7 64-64l0-92.1c0-5.2-.6-10.4-1.9-15.5l-57-227.9C446 52 420.4 32 391 32L121 32zm0 64l270 0 48 192-51.2 0c-12.1 0-23.2 6.8-28.6 17.7l-14.3 28.6c-5.4 10.8-16.5 17.7-28.6 17.7l-120.4 0c-12.1 0-23.2-6.8-28.6-17.7l-14.3-28.6c-5.4-10.8-16.5-17.7-28.6-17.7L73 288 121 96z" fill="currentColor" />
         </svg> Newsletter
       </a>
@@ -38,7 +38,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="https://docs.pdap.io/" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-book" data-icon="book" data-prefix="fas" focusable="false" role="img" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-book text-brand-wine-100 dark:text-brand-wine-800" data-icon="book" data-prefix="fas" focusable="false" role="img" viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M96 0C43 0 0 43 0 96L0 416c0 53 43 96 96 96l288 0 32 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l0-64c17.7 0 32-14.3 32-32l0-320c0-17.7-14.3-32-32-32L384 0 96 0zm0 384l256 0 0 64L96 448c-17.7 0-32-14.3-32-32s14.3-32 32-32zm32-240c0-8.8 7.2-16 16-16l192 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-192 0c-8.8 0-16-7.2-16-16zm16 48l192 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-192 0c-8.8 0-16-7.2-16-16s7.2-16 16-16z" fill="currentColor" />
         </svg> Docs
       </a>
@@ -46,7 +46,7 @@ exports[`Footer component > Renders a footer 1`] = `
     </li>
     <li class="w-max">
       <a class="text-neutral-50 dark:text-neutral-950" href="mailto:contact@pdap.io" rel="noreferrer" target="_blank">
-        <svg aria-hidden="true" class="svg-inline--fa fa-envelope" data-icon="envelope" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" class="svg-inline--fa fa-envelope text-brand-wine-100 dark:text-brand-wine-800" data-icon="envelope" data-prefix="fas" focusable="false" role="img" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
           <path class="" d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4L236.8 313.6c11.4 8.5 27 8.5 38.4 0L492.8 150.4c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48L48 64zM0 176L0 384c0 35.3 28.7 64 64 64l384 0c35.3 0 64-28.7 64-64l0-208L294.4 339.2c-22.8 17.1-54 17.1-76.8 0L0 176z" fill="currentColor" />
         </svg> Email
       </a>

--- a/src/components/Footer/constants.ts
+++ b/src/components/Footer/constants.ts
@@ -3,9 +3,9 @@
  */
 export const FOOTER_LINK_ICONS = {
 	GITHUB: 'github',
-	LINKEDIN: 'linkedin',
 	DISCORD: 'discord',
 	JOBS: 'jobs',
 	NEWSLETTER: 'newsletter',
 	DOCS: 'docs',
+	EMAIL: 'email',
 } as const;

--- a/src/components/Footer/footer.spec.ts
+++ b/src/components/Footer/footer.spec.ts
@@ -2,15 +2,7 @@ import PdapFooter from './PdapFooter.vue';
 import { RouterLinkStub, mount } from '@vue/test-utils';
 import { describe, expect, test, beforeEach, vi, afterEach } from 'vitest';
 
-const mockFundraisingData = {
-	raised: 5000,
-	goal: 10000,
-};
-
 const base = {
-	props: {
-		fundraisingData: mockFundraisingData,
-	},
 	stubs: {
 		RouterLink: RouterLinkStub,
 		FontAwesomeIcon: true,
@@ -50,92 +42,6 @@ describe('Footer component', () => {
 		expect(wrapper.html()).toContain('Newsletter');
 		expect(wrapper.html()).toContain('Docs');
 		expect(wrapper.html()).toContain('Email');
-	});
-
-	// Fundraising Section
-	describe('Fundraising meter', () => {
-		test('Displays correct fundraising amounts', () => {
-			const wrapper = mount(PdapFooter, base);
-			const fundraisingText = wrapper
-				.find('a[href="https://pdap.io/donate"]')
-				.text();
-
-			expect(fundraisingText).toContain('$5,000');
-			expect(fundraisingText).toContain('$10,000');
-		});
-
-		test('Shows celebration emoji when goal is met', () => {
-			const wrapper = mount(PdapFooter, {
-				...base,
-				props: {
-					fundraisingData: {
-						raised: 10000,
-						goal: 10000,
-					},
-				},
-			});
-
-			expect(wrapper.html()).toContain('🎉');
-		});
-
-		test('Does not show celebration emoji when goal is not met', () => {
-			const wrapper = mount(PdapFooter, base);
-			expect(wrapper.html()).not.toContain('🎉');
-		});
-	});
-
-	describe('Progress bar animation', () => {
-		// test('Sets initial progress to 0% on mount', () => {
-		// 	mount(PdapFooter, base);
-
-		// 	expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
-		// 		'--fundraising-progress',
-		// 		'0%'
-		// 	);
-		// });
-
-		// test('Animates to correct percentage after mount', async () => {
-		// 	mount(PdapFooter, base);
-
-		// 	// Fast-forward past the setTimeout
-		// 	vi.runAllTimers();
-
-		// 	expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
-		// 		'--fundraising-progress',
-		// 		'50%'
-		// 	);
-		// });
-
-		test('Progress bar has correct transition classes', () => {
-			const wrapper = mount(PdapFooter, base);
-			const progressBar = wrapper.find('.rounded-full');
-
-			expect(progressBar.classes()).toContain('before:transition-[width]');
-			expect(progressBar.classes()).toContain('before:duration-1000');
-			expect(progressBar.classes()).toContain('before:ease-out');
-		});
-
-		test('Rounds right corner when goal is met', () => {
-			const wrapper = mount(PdapFooter, {
-				...base,
-				props: {
-					fundraisingData: {
-						raised: 10000,
-						goal: 10000,
-					},
-				},
-			});
-
-			const progressBar = wrapper.find('.rounded-full');
-			expect(progressBar.classes()).toContain('before:rounded-r-full');
-		});
-
-		test('Does not round right corner when goal is not met', () => {
-			const wrapper = mount(PdapFooter, base);
-
-			const progressBar = wrapper.find('.rounded-full');
-			expect(progressBar.classes()).not.toContain('before:rounded-r-full');
-		});
 	});
 });
 

--- a/src/components/Footer/footer.spec.ts
+++ b/src/components/Footer/footer.spec.ts
@@ -81,7 +81,9 @@ describe('Link behavior', () => {
 
 	test('Internal links should not open in new tab', () => {
 		const wrapper = mount(PdapFooter, base);
-		const internalLinks = wrapper.findAll('a:not([href^="http"]):not([href^="mailto"])');
+		const internalLinks = wrapper.findAll(
+			'a:not([href^="http"]):not([href^="mailto"])'
+		);
 
 		internalLinks.forEach((link) => {
 			expect(link.attributes('target')).toBeFalsy();

--- a/src/components/Footer/footer.spec.ts
+++ b/src/components/Footer/footer.spec.ts
@@ -46,10 +46,10 @@ describe('Footer component', () => {
 		// Verify specific links exist
 		expect(wrapper.html()).toContain('Github');
 		expect(wrapper.html()).toContain('Discord');
-		expect(wrapper.html()).toContain('LinkedIn');
 		expect(wrapper.html()).toContain('Jobs');
 		expect(wrapper.html()).toContain('Newsletter');
 		expect(wrapper.html()).toContain('Docs');
+		expect(wrapper.html()).toContain('Email');
 	});
 
 	// Fundraising Section
@@ -175,7 +175,7 @@ describe('Link behavior', () => {
 
 	test('Internal links should not open in new tab', () => {
 		const wrapper = mount(PdapFooter, base);
-		const internalLinks = wrapper.findAll('a:not([href^="http"])');
+		const internalLinks = wrapper.findAll('a:not([href^="http"]):not([href^="mailto"])');
 
 		internalLinks.forEach((link) => {
 			expect(link.attributes('target')).toBeFalsy();

--- a/src/components/Footer/types.ts
+++ b/src/components/Footer/types.ts
@@ -8,10 +8,3 @@ export interface PdapFooterSocialLinks {
 }
 export type FooterIconName =
 	(typeof FOOTER_LINK_ICONS)[keyof typeof FOOTER_LINK_ICONS];
-
-export interface PdapFooterProps {
-	fundraisingData: {
-		raised: number;
-		goal: number;
-	};
-}

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -69,11 +69,12 @@ export default {
 
 <style>
 .pdap-header {
-	@apply dark:bg-neutral-300 relative bg-neutral-50 flex justify-between p-4 md:p-4 w-full z-50;
+	@apply dark:bg-brand-wine-800 relative bg-neutral-50 flex justify-between p-4 md:p-4 w-full z-50;
 }
 
 .logo {
-	@apply decoration-0 relative max-w-[80%] text-xl font-bold px-2 py-1 outline outline-wineneutral-500 text-brand-wine-400;
+	@apply decoration-0 relative max-w-[80%] text-xl font-bold px-2 py-1;
+	@apply outline outline-wineneutral-500 text-brand-wine-400 dark:outline-wineneutral-500 dark:text-brand-wine-50;
 	@apply lg:text-lg;
 	@apply xs:max-w-none;
 }

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -1,9 +1,13 @@
 <template>
 	<header ref="el" class="pdap-header">
 		<a v-if="!navLogoLinkIsPath" :href="logoAnchorPath" class="logo"
-			>Police Data Access Point</a>
+			>
+			<FontAwesomeIcon :icon="faArrowsToCircle" />
+			&nbsp;Police Data Access Point</a>
 		<router-link v-else :to="logoAnchorPath" class="logo"
-			>Police Data Access Point</router-link>
+			>
+			<FontAwesomeIcon :icon="faArrowsToCircle" />
+			&nbsp;Police Data Access Point</router-link>
 		<PdapNav />
 	</header>
 </template>
@@ -13,6 +17,8 @@ import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { RouterLink } from 'vue-router';
 import PdapNav from '../Nav/PdapNav.vue';
 import { PdapHeaderProps } from './types';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { faArrowsToCircle } from '@fortawesome/free-solid-svg-icons';
 
 // Props
 const props = withDefaults(defineProps<PdapHeaderProps>(), {

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -1,19 +1,9 @@
 <template>
 	<header ref="el" class="pdap-header">
-		<a v-if="!navLogoLinkIsPath" :href="logoImageAnchorPath" class="logo"
-			><img
-				:src="logoImageSrc"
-				loading="lazy"
-				width="250"
-				alt="Police Data Accessibility Project Logo"
-		/></a>
-		<router-link v-else :to="logoImageAnchorPath" class="logo"
-			><img
-				:src="logoImageSrc"
-				loading="lazy"
-				width="250"
-				alt="Police Data Accessibility Project Logo"
-		/></router-link>
+		<a v-if="!navLogoLinkIsPath" :href="logoAnchorPath" class="logo"
+			>Police Data Access Point</a>
+		<router-link v-else :to="logoAnchorPath" class="logo"
+			>Police Data Access Point</router-link>
 		<PdapNav />
 	</header>
 </template>
@@ -23,17 +13,15 @@ import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { RouterLink } from 'vue-router';
 import PdapNav from '../Nav/PdapNav.vue';
 import { PdapHeaderProps } from './types';
-import lockup from '../../assets/lockup.svg';
 
 // Props
 const props = withDefaults(defineProps<PdapHeaderProps>(), {
-	logoImageSrc: lockup,
-	logoImageAnchorPath: '/',
+	logoAnchorPath: '/',
 });
 
 // Vars
 const el = ref<HTMLElement | null>(null);
-const navLogoLinkIsPath = props.logoImageAnchorPath.startsWith('/');
+const navLogoLinkIsPath = props.logoAnchorPath.startsWith('/');
 
 // Lifecycle methods
 onMounted(() => {
@@ -62,7 +50,7 @@ function getHeightAndSetToCSSVar() {
  *
  * ## Props
  * @prop {string} logoImageSrc Src for the PDAP logo image to be displayed
- * @prop {string } logoImageAnchorPath Path for the link that wraps the PDAP logo image
+ * @prop {string } logoAnchorPath Path for the link that wraps the PDAP logo image
  *
  * ## Notes
  * The `Header` component does not require any props to be passed. But keep in mind that it is responsible for rendering the `Nav` component. Consuming applications will need to `provide` an array of nav links -- **there are no defaults for this**, you must `provide` these links either 1\. in a layout component (see example below), at the route level, or at the app level. This allows for flexibility in which links are rendered on which routes
@@ -83,7 +71,4 @@ export default {
 	@apply xs:max-w-none;
 }
 
-.logo img {
-	@apply dark:invert;
-}
 </style>

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -67,7 +67,8 @@ export default {
 }
 
 .logo {
-	@apply decoration-0 relative max-w-[80%] px-4;
+	@apply decoration-0 relative max-w-[80%] text-xl font-semibold px-4 text-brand-wine-400;
+	@apply lg:text-lg;
 	@apply xs:max-w-none;
 }
 

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -69,11 +69,11 @@ export default {
 
 <style>
 .pdap-header {
-	@apply dark:bg-neutral-300 relative bg-neutral-50 flex justify-between p-4 md:p-6 w-full z-50;
+	@apply dark:bg-neutral-300 relative bg-neutral-50 flex justify-between p-4 md:p-4 w-full z-50;
 }
 
 .logo {
-	@apply decoration-0 relative max-w-[80%] text-xl font-bold p-2 outline outline-wineneutral-500 text-brand-wine-400;
+	@apply decoration-0 relative max-w-[80%] text-xl font-bold px-2 py-1 outline outline-wineneutral-500 text-brand-wine-400;
 	@apply lg:text-lg;
 	@apply xs:max-w-none;
 }

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -67,7 +67,7 @@ export default {
 }
 
 .logo {
-	@apply decoration-0 relative max-w-[80%] text-xl font-semibold px-4 text-brand-wine-400;
+	@apply decoration-0 relative max-w-[80%] text-xl font-bold p-2 outline outline-wineneutral-500 text-brand-wine-400;
 	@apply lg:text-lg;
 	@apply xs:max-w-none;
 }

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -1,13 +1,13 @@
 <template>
 	<header ref="el" class="pdap-header">
-		<a v-if="!navLogoLinkIsPath" :href="logoAnchorPath" class="logo"
-			>
+		<a v-if="!navLogoLinkIsPath" :href="logoAnchorPath" class="logo">
 			<FontAwesomeIcon :icon="faArrowsToCircle" />
-			&nbsp;Police Data Access Point</a>
-		<router-link v-else :to="logoAnchorPath" class="logo"
-			>
+			&nbsp;Police Data Access Point</a
+		>
+		<router-link v-else :to="logoAnchorPath" class="logo">
 			<FontAwesomeIcon :icon="faArrowsToCircle" />
-			&nbsp;Police Data Access Point</router-link>
+			&nbsp;Police Data Access Point</router-link
+		>
 		<PdapNav />
 	</header>
 </template>
@@ -77,5 +77,4 @@ export default {
 	@apply lg:text-lg;
 	@apply xs:max-w-none;
 }
-
 </style>

--- a/src/components/Header/README.md
+++ b/src/components/Header/README.md
@@ -4,8 +4,7 @@
 
 | name                  | required? | types    | description            | default                                                    |
 | --------------------- | --------- | -------- | ---------------------- | ---------------------------------------------------------- |
-| `logoImageSrc`        | no        | `string` | Source of logo image   | `'node_modules/pdap-design-system/dist/images/lockup.svg'` |
-| `logoImageAnchorPath` | no        | `string` | Flex alignment presets | `/`                                                        |
+| `logoAnchorPath` | no        | `string` | Flex alignment presets | `/`                                                        |
 
 ## Notes
 

--- a/src/components/Header/header.spec.ts
+++ b/src/components/Header/header.spec.ts
@@ -51,40 +51,27 @@ describe('Header component', () => {
 	});
 
 	// Props
-	// Props - logo src
-	test('Renders header with default logo src', () => {
-		const wrapper = mount(PdapHeader, base);
-		expect(wrapper.props().logoImageSrc).toBe('/src/assets/lockup.svg');
-	});
-
-	test('Renders header with custom logo src', () => {
-		const wrapper = mount(PdapHeader, {
-			...base,
-			props: { logoImageSrc: 'test' },
-		});
-		expect(wrapper.props().logoImageSrc).toBe('test');
-	});
 
 	// Props - anchor path
 	test('Renders header with default logo anchor path', () => {
 		const wrapper = mount(PdapHeader, base);
-		expect(wrapper.props().logoImageAnchorPath).toBe('/');
+		expect(wrapper.props().logoAnchorPath).toBe('/');
 	});
 
 	test('Renders header with custom logo anchor path', () => {
 		const wrapper = mount(PdapHeader, {
 			...base,
-			props: { logoImageAnchorPath: '/test' },
+			props: { logoAnchorPath: '/test' },
 		});
-		expect(wrapper.props().logoImageAnchorPath).toBe('/test');
+		expect(wrapper.props().logoAnchorPath).toBe('/test');
 	});
 
 	test('Renders header with custom logo anchor href', () => {
 		const wrapper = mount(PdapHeader, {
 			...base,
-			props: { logoImageAnchorPath: 'www.test.com' },
+			props: { logoAnchorPath: 'www.test.com' },
 		});
-		expect(wrapper.props().logoImageAnchorPath).toBe('www.test.com');
+		expect(wrapper.props().logoAnchorPath).toBe('www.test.com');
 	});
 
 	test('Header is unmounted from the DOM', async () => {

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -1,4 +1,3 @@
 export interface PdapHeaderProps {
-	logoImageSrc?: string;
-	logoImageAnchorPath?: string;
+	logoAnchorPath?: string;
 }

--- a/src/components/Nav/PdapNav.vue
+++ b/src/components/Nav/PdapNav.vue
@@ -191,7 +191,7 @@ export default {
 	}
 
 	.pdap-nav-link-current {
-		@apply lg:outline-neutral-800 lg:outline text-neutral-950;
+		@apply lg:outline-wineneutral-800 lg:outline text-neutral-950;
 	}
 
 	.pdap-nav-link-current-exact {

--- a/src/components/Nav/PdapNav.vue
+++ b/src/components/Nav/PdapNav.vue
@@ -187,7 +187,7 @@ export default {
 	}
 
 	.pdap-nav-link {
-		@apply decoration-0 font-medium p-2 text-left text-xl lg:text-lg text-neutral-950;
+		@apply decoration-0 font-medium py-1 px-2 text-left text-xl lg:text-lg text-neutral-950;
 	}
 
 	.pdap-nav-link-current {

--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -2,8 +2,6 @@
 import { Header, Footer } from '../components';
 import { provide } from 'vue';
 import { RouterView } from 'vue-router';
-// import acronym from '';
-// import lockup from 'pdap-design-system/images/lockup.svg';
 
 const links = [
 	{

--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -43,5 +43,5 @@ provide('navLinks', links);
 <template>
 	<Header />
 	<RouterView />
-	<Footer :fundraising-data="{ raised: 1000, goal: 5000 }" />
+	<Footer />
 </template>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -145,8 +145,8 @@
 		@apply border-2 border-transparent border-solid outline-none;
 	}
 
-a:focus,
-a:focus-visible,
+a:focus:not(.pdap-nav-link),
+a:focus-visible:not(.pdap-nav-link),
 button:focus,
 button:focus-visible,
 [role="button"]:focus,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -76,12 +76,12 @@
 	}
 
 	h2 {
-		@apply font-bold mb-4 mt-8 text-2xl;
+		@apply font-semibold mb-4 mt-8 text-2xl;
 		@apply md:text-4xl;
 	}
 
 	h3 {
-		@apply font-extrabold mb-2 mt-8 text-med tracking-[.1em] uppercase;
+		@apply font-bold mb-2 mt-8 text-med tracking-[.1em] uppercase;
 		@apply md:text-lg;
 	}
 


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. feat(components): add MyFancyComponent -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->
# Fix: visual tweaks

<!-- What is the rationale for the changes? -->
## Background
- part of fixing https://github.com/Police-Data-Accessibility-Project/design-system/issues/123
- will fix #131 
- related to https://github.com/Police-Data-Accessibility-Project/pdap.io/pull/211

<!-- What is the description of the changes? -->
## Description
- removes logo as part of the header and footer, and all references to such practices
  - the "logo" is now just a fontawesome icon (optional) and "Police Data Access Point" in public sans
- tweaks header weights
- tunes the footer

## Acceptance Criteria
<!-- What are the steps to test the changes? -->
- terminal: `npm i && npm run dev` 
- ensure the demo looks nice