### PR TITLE
feat(components): async typeahead dropdown component

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1,6 +1,7 @@
 # Component Documentation
 <!-- This file is auto-generated from README.md files contained in the components directory, no need to edit this file directly. -->
 
+- [AsyncTypeahead](../src/components/AsyncTypeahead//README.md)
 - [Breadcrumbs](../src/components/Breadcrumbs//README.md)
 - [Button](../src/components/Button//README.md)
 - [Dropdown](../src/components/Dropdown//README.md)

--- a/src/components/AsyncTypeahead/AsyncTypeahead.vue
+++ b/src/components/AsyncTypeahead/AsyncTypeahead.vue
@@ -85,7 +85,8 @@ import { PdapAsyncTypeaheadProps } from './types';
 /* Props and emits */
 const props = withDefaults(defineProps<PdapAsyncTypeaheadProps<T>>(), {
 	placeholder: '',
-	formatItemForDisplay: (item: T) => JSON.stringify(item),
+	formatItemForDisplay: (item: T) =>
+		typeof item === 'string' ? item : JSON.stringify(item),
 });
 const emit = defineEmits(['onInput', 'onFocus', 'onBlur', 'selectItem']);
 

--- a/src/components/AsyncTypeahead/AsyncTypeahead.vue
+++ b/src/components/AsyncTypeahead/AsyncTypeahead.vue
@@ -1,0 +1,264 @@
+<!-- TODO: Once this component is sufficiently generic, move to design-system? -->
+<template>
+	<div
+		:id="wrapperId"
+		data-test="typeahead-wrapper"
+		class="pdap-typeahead"
+		:class="{ 'pdap-typeahead-expanded': isListOpen }"
+	>
+		<label v-if="$slots.label" class="col-span-2" :for="id">
+			<slot name="label" />
+		</label>
+
+		<div v-if="$slots.error && error" class="pdap-input-error-message">
+			<!-- TODO: aria-aware error handling?? Not just here but in other input components as well? -->
+			<slot name="error" />
+		</div>
+		<div v-else-if="error" class="pdap-input-error-message">{{ error }}</div>
+
+		<input
+			:id="id"
+			ref="inputRef"
+			v-model="input"
+			data-test="typeahead-input"
+			class="pdap-typeahead-input"
+			type="text"
+			:placeholder="placeholder"
+			autocomplete="off"
+			v-bind="$attrs"
+			@input="onInput"
+			@focus="onFocus"
+			@blur="onBlur"
+			@keydown.down.prevent="onArrowDown"
+		/>
+		<ul
+			v-if="itemsToDisplay?.length && inputRef?.value"
+			data-test="typeahead-list"
+			class="pdap-typeahead-list"
+		>
+			<li
+				v-for="(item, index) in itemsToDisplay"
+				:key="index"
+				class="pdap-typeahead-list-item"
+				data-test="typeahead-list-item"
+				role="button"
+				tabindex="0"
+				@click="() => selectItem(item)"
+				@keydown.enter.prevent="selectItem(item)"
+				@keydown.down.prevent="onArrowDown"
+				@keydown.up.prevent="onArrowUp"
+			>
+				<slot v-if="$slots.item" name="item" v-bind="item" />
+				<span v-else>{{ boldMatchText(formatItemForDisplay(item)) }}</span>
+			</li>
+		</ul>
+		<ul
+			v-else-if="typeof itemsToDisplay === 'undefined' && input.length > 1"
+			class="pdap-typeahead-list"
+			data-test="typeahead-list-not-found"
+		>
+			<li class="max-w-[unset]">
+				<slot
+					v-if="$slots['not-found']"
+					name="not-found"
+					v-bind="$slots['not-found'] ?? {}"
+				/>
+				<span v-else>
+					<strong>No results found.</strong>
+					Please check your spelling.
+				</span>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<script setup lang="ts" generic="T">
+import {
+	ref,
+	computed,
+	onMounted,
+	onUnmounted,
+	watch,
+	onBeforeUpdate,
+} from 'vue';
+import { PdapAsyncTypeaheadProps } from './types';
+
+/* Props and emits */
+const props = withDefaults(defineProps<PdapAsyncTypeaheadProps<T>>(), {
+	placeholder: '',
+	formatItemForDisplay: (item: T) => JSON.stringify(item),
+});
+const emit = defineEmits(['onInput', 'onFocus', 'onBlur', 'selectItem']);
+
+/* Refs and reactive vars */
+const inputRef = ref();
+const input = ref('');
+
+/* Computed vars */
+const wrapperId = computed(() => `${props.id}_wrapper`);
+const itemsToDisplay = computed(() => props.items);
+const isListOpen = computed(
+	() =>
+		(itemsToDisplay.value?.length && inputRef?.value?.value) ||
+		(typeof itemsToDisplay.value === 'undefined' && input.value.length > 1)
+);
+
+/* Lifecycle methods and listeners */
+onMounted(() => {
+	window.addEventListener('resize', setInputPositionForList);
+});
+
+onBeforeUpdate(setInputPositionForList);
+
+onUnmounted(() => {
+	window.removeEventListener('resize', setInputPositionForList);
+});
+
+/* Watch expressions */
+watch(
+	() => inputRef.value,
+	(ref) => {
+		if (ref) setInputPositionForList();
+	}
+);
+
+/* Methods */
+function setInputPositionForList() {
+	document.documentElement.style.setProperty(
+		'--typeaheadBottom',
+		inputRef.value.offsetTop + inputRef.value.offsetHeight + 'px'
+	);
+	document.documentElement.style.setProperty(
+		'--typeaheadListWidth',
+		inputRef.value.offsetWidth + 'px'
+	);
+}
+function onInput(e: Event) {
+	emit('onInput', e);
+}
+function onFocus(e?: Event) {
+	if (Array.isArray(itemsToDisplay.value) && !itemsToDisplay.value.length) {
+		clearInput();
+		emit('selectItem', undefined);
+	}
+
+	if (e) emit('onFocus', e);
+}
+function onBlur(e: Event) {
+	emit('onBlur', e);
+}
+
+function onArrowDown() {
+	const items = Array.from(
+		document.getElementsByClassName('pdap-typeahead-list-item')
+	) as HTMLElement[];
+
+	const focusedIndex = items.indexOf(document.activeElement as HTMLElement); // Casting is okay here because we don't need to access any of the missing properties.
+
+	if (focusedIndex === items.length - 1) return;
+
+	if (focusedIndex === -1) {
+		items[0].focus();
+	} else {
+		items[focusedIndex + 1].focus();
+	}
+}
+
+function onArrowUp() {
+	const items = Array.from(
+		document.getElementsByClassName('pdap-typeahead-list-item')
+	) as HTMLElement[];
+
+	const focusedIndex = items.indexOf(document.activeElement as HTMLElement);
+
+	if (focusedIndex === 0) {
+		inputRef.value.focus();
+	} else {
+		items[focusedIndex - 1].focus();
+	}
+}
+
+function selectItem(item: T) {
+	input.value = props.formatItemForDisplay
+		? props.formatItemForDisplay(item)
+		: String(item);
+
+	inputRef.value.blur();
+	emit('selectItem', item);
+}
+
+function escapeRegExp(s: string) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+function boldMatchText(text: string) {
+	const regexp = new RegExp(`(${escapeRegExp(input.value)})`, 'ig');
+	return text.replace(regexp, '<strong>$1</strong>');
+}
+function clearInput() {
+	input.value = '';
+}
+// function getInput() {
+// 	return inputRef.value;
+// }
+function focusInput() {
+	inputRef.value.focus();
+	onFocus();
+}
+// function blurInput() {
+// 	inputRef.value.blur();
+// 	onBlur();
+// }
+
+defineExpose({
+	boldMatchText,
+	clearInput,
+	focusInput,
+	get value() {
+		return input.value;
+	},
+});
+</script>
+
+<style>
+.pdap-typeahead {
+	@apply leading-normal w-full flex flex-col;
+}
+
+.pdap-typeahead label {
+	@apply max-w-[max-content] text-lg py-1 font-medium;
+}
+
+.pdap-typeahead-input {
+	@apply rounded-md;
+}
+
+.pdap-typeahead-input,
+.pdap-typeahead-list {
+	@apply bg-neutral-50 border-2 border-neutral-500 border-solid p-2 text-neutral-950;
+}
+
+.pdap-typeahead-input::placeholder {
+	@apply text-neutral-600 text-lg;
+}
+
+.pdap-typeahead-input:focus,
+.pdap-typeahead-input:focus-within,
+.pdap-typeahead-input:focus-visible {
+	@apply border-2 border-brand-gold border-solid outline-none;
+}
+
+.pdap-typeahead-list {
+	@apply absolute w-[var(--typeaheadListWidth)] top-[var(--typeaheadBottom)] z-50 overflow-scroll;
+}
+
+.pdap-typeahead-list-item {
+	@apply mt-1 max-w-[unset] p-2 flex items-center gap-6 text-sm md:text-lg;
+}
+
+.pdap-typeahead-list-item:focus,
+.pdap-typeahead-list-item:focus-visible,
+.pdap-typeahead-list-item:focus-within,
+.pdap-typeahead-list-item:hover {
+	@apply outline-none text-neutral-950 bg-neutral-300;
+}
+</style>

--- a/src/components/AsyncTypeahead/AsyncTypeahead.vue
+++ b/src/components/AsyncTypeahead/AsyncTypeahead.vue
@@ -1,4 +1,3 @@
-<!-- TODO: Once this component is sufficiently generic, move to design-system? -->
 <template>
 	<div
 		:id="wrapperId"

--- a/src/components/AsyncTypeahead/README.md
+++ b/src/components/AsyncTypeahead/README.md
@@ -1,0 +1,13 @@
+# AsyncTypeahead
+
+This component accepts 
+
+## Props
+
+| name        | required? | types                                    | description                | default   |
+| ----------- | --------- | ---------------------------------------- | -------------------------- | --------- |
+| `isLoading` | no        | `boolean`                                | Request state              | `false`   |
+| `intent`    | yes       | `"primary" \| "secondary" \| "tertiary"` | Determines style of button | `primary` |
+
+## Example
+

--- a/src/components/AsyncTypeahead/README.md
+++ b/src/components/AsyncTypeahead/README.md
@@ -1,13 +1,76 @@
 # AsyncTypeahead
 
-This component accepts 
+This component handles single-item selection from a dropdown of items passed into it.  
+It emits an `onInput` event when a user types into the input.  
+It accepts an array of generically typed `items`, along with props and slots for formatting whatever type is passed with the array.  
+Using these in combination allows us to asynchronously (or sync, if you like) fetch items based on user input and display them in a dropdown for selection.  
+There are also several methods exposed that can be accessed via a ref for use in components passed as slots.  
+
+NOTE: this does not currently work with the form paradigm that other inputs work with. This is largely because we've used it so far with objects, whose properties need to be formatted into strings for display in the typeahead input after selection. In the future, we'll want to plug this in in a way that the object itself is represented in the form values object. But for now, just use the `selectItem` emit to handle values and merge with form value objects. See [the usage in pdap.io](https://github.com/Police-Data-Accessibility-Project/pdap.io/blob/dev/src/pages/data-source/create.vue#L67-L115) for an example.
 
 ## Props
 
-| name        | required? | types                                    | description                | default   |
-| ----------- | --------- | ---------------------------------------- | -------------------------- | --------- |
-| `isLoading` | no        | `boolean`                                | Request state              | `false`   |
-| `intent`    | yes       | `"primary" \| "secondary" \| "tertiary"` | Determines style of button | `primary` |
+| name                   | required? | types                            | description                                                                   | default                                                                            |
+| ---------------------- | --------- | -------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `id`                   | yes       | `string`                         | id for the typeahead input                                                    | n/a                                                                                |
+| `placeholder`          | no        | `string`                         | Placeholder text for the input                                                | `''`                                                                               |
+| `items`                | yes       | `GenericTypeT[] \| undefined`    | Array of items from which to select                                           | n/a                                                                                |
+| `formatItemForDisplay` | no        | `(item: GenericTypeT) => string` | Formatter for items rendered (recommended to pass unless item is type string) | `(item: GenericTypeT) =>  typeof item === 'string' ? item : JSON.stringify(item),` |
+| `error`                | no        | `string`                         | Error message if typeahead search or form validation fails                    | n/a                                                                                |
+
+## Slots
+
+| name        | required?      | types     | description                                                     | default                                                                        |
+| ----------- | -------------- | --------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `error`     | no<sup>*</sup> | `Element` | slot content to be rendered as error                            | n/a                                                                            |
+| `label`     | yes            | `Element` | slot content to be rendered as label                            | n/a                                                                            |
+| `item`      | no             | `Element` | slot content rendered with `item: GenericTypeT` passed as props | n/a - If slot not passed, we simply call `formatItemForDisplay` on each `item` |
+| `not-found` | no             | `Element` | slot content rendered when no item found                        | `<strong>No results found.</strong> Please check your spelling.`               |
+
+## Emits
+
+| name         | description                      |
+| ------------ | -------------------------------- |
+| `selectItem` | when item selected from dropdown |
+| `onFocus`    | when input is focused            |
+| `onBlur`     | when input is blurred            |
+| `onInput`    | when input takes new values      |
 
 ## Example
 
+```vue
+		<AsyncTypeahead
+			id="typeahead"
+			ref="typeaheadRef"
+			class="md:col-span-2"
+			:error="typeaheadError"
+			:format-item-for-display="getFullText"
+			:items="items"
+			placeholder="Search for a person"
+			@select-item="
+				(item) => {
+					if (item) {
+						selectedItems = [...selectedItems, item];
+						items = [];
+					}
+				}
+			"
+			@on-input="fetchTypeaheadResults"
+		>
+			<!-- Item to render passed as scoped slot -->
+			<template #item="item">
+				<span v-html="typeaheadRef?.boldMatchText(getFullText(item))" />
+				<span class="select">Select</span>
+			</template>
+			<template #not-found>
+				<span>
+					We can't find the person you're looking for. Is their name spelled
+					correctly? If our database is missing something, please reach us at
+					<a href="mailto:contact@pdap.io">contact@pdap.io</a>
+				</span>
+			</template>
+		</AsyncTypeahead>
+```
+
+<!-- TODO: update pdap.io link when dev -> main -->
+Or see the [typeahead demo page](../../demo/pages/TypeaheadDemo.vue) or [the usage in pdap.io](https://github.com/Police-Data-Accessibility-Project/pdap.io/blob/dev/src/pages/data-source/create.vue#L67-L115) for more.

--- a/src/components/AsyncTypeahead/__snapshots__/typeaheadinput.spec.ts.snap
+++ b/src/components/AsyncTypeahead/__snapshots__/typeaheadinput.spec.ts.snap
@@ -1,0 +1,94 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TypeaheadInput > emits onBlur event 1`] = `
+<div class="pdap-typeahead" id="_wrapper">
+  <!--v-if-->
+  <!--v-if-->
+  <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
+  <!--v-if-->
+</div>
+`;
+
+exports[`TypeaheadInput > emits onFocus event and clears input if no items 1`] = `
+<div class="pdap-typeahead" id="_wrapper">
+  <!--v-if-->
+  <!--v-if-->
+  <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
+  <!--v-if-->
+</div>
+`;
+
+exports[`TypeaheadInput > emits onInput event 1`] = `
+<div class="pdap-typeahead" id="_wrapper">
+  <!--v-if-->
+  <!--v-if-->
+  <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
+  <!--v-if-->
+</div>
+`;
+
+exports[`TypeaheadInput > focuses input on arrow up from first list item 1`] = `
+<div class="pdap-typeahead" id="_wrapper">
+  <!--v-if-->
+  <!--v-if-->
+  <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
+  <ul class="pdap-typeahead-list">
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>antine"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>iathan"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>i"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>ant"</span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TypeaheadInput > focuses next list item on arrow down 1`] = `
+<div class="pdap-typeahead" id="_wrapper">
+  <!--v-if-->
+  <!--v-if-->
+  <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
+  <ul class="pdap-typeahead-list">
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>antine"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>iathan"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>i"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>ant"</span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`TypeaheadInput > focuses previous list item on arrow up 1`] = `
+<div class="pdap-typeahead" id="_wrapper">
+  <!--v-if-->
+  <!--v-if-->
+  <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
+  <ul class="pdap-typeahead-list">
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>antine"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>iathan"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>i"</span>
+    </li>
+    <li class="pdap-typeahead-list-item" role="button" tabindex="0">
+      <span>"<strong>Lev</strong>ant"</span>
+    </li>
+  </ul>
+</div>
+`;

--- a/src/components/AsyncTypeahead/__snapshots__/typeaheadinput.spec.ts.snap
+++ b/src/components/AsyncTypeahead/__snapshots__/typeaheadinput.spec.ts.snap
@@ -34,16 +34,24 @@ exports[`TypeaheadInput > focuses input on arrow up from first list item 1`] = `
   <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
   <ul class="pdap-typeahead-list">
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>antine"</span>
+      <span>
+        <strong>Lev</strong>antine
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>iathan"</span>
+      <span>
+        <strong>Lev</strong>iathan
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>i"</span>
+      <span>
+        <strong>Lev</strong>i
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>ant"</span>
+      <span>
+        <strong>Lev</strong>ant
+      </span>
     </li>
   </ul>
 </div>
@@ -56,16 +64,24 @@ exports[`TypeaheadInput > focuses next list item on arrow down 1`] = `
   <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
   <ul class="pdap-typeahead-list">
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>antine"</span>
+      <span>
+        <strong>Lev</strong>antine
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>iathan"</span>
+      <span>
+        <strong>Lev</strong>iathan
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>i"</span>
+      <span>
+        <strong>Lev</strong>i
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>ant"</span>
+      <span>
+        <strong>Lev</strong>ant
+      </span>
     </li>
   </ul>
 </div>
@@ -78,16 +94,24 @@ exports[`TypeaheadInput > focuses previous list item on arrow up 1`] = `
   <input autocomplete="off" class="pdap-typeahead-input" id placeholder type="text">
   <ul class="pdap-typeahead-list">
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>antine"</span>
+      <span>
+        <strong>Lev</strong>antine
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>iathan"</span>
+      <span>
+        <strong>Lev</strong>iathan
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>i"</span>
+      <span>
+        <strong>Lev</strong>i
+      </span>
     </li>
     <li class="pdap-typeahead-list-item" role="button" tabindex="0">
-      <span>"<strong>Lev</strong>ant"</span>
+      <span>
+        <strong>Lev</strong>ant
+      </span>
     </li>
   </ul>
 </div>

--- a/src/components/AsyncTypeahead/index.ts
+++ b/src/components/AsyncTypeahead/index.ts
@@ -1,0 +1,1 @@
+export { default as AsyncTypeahead } from './AsyncTypeahead.vue';

--- a/src/components/AsyncTypeahead/typeaheadinput.spec.ts
+++ b/src/components/AsyncTypeahead/typeaheadinput.spec.ts
@@ -1,0 +1,224 @@
+import TypeaheadInput from './AsyncTypeahead.vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+
+const MOCK_SEARCH_VALUE = 'lev';
+const MOCK_ITEMS = ['Levantine', 'Leviathan', 'Levi', 'Levant'];
+// To do: update test to handle more complex items
+// const MOCK_ITEMS = [
+// 	{
+// 		county: 'Hockley',
+// 		display_name: 'Levelland',
+// 		locality: 'Levelland',
+// 		state: 'Texas',
+// 		type: 'Locality',
+// 	},
+// 	{
+// 		county: 'Franklin',
+// 		display_name: 'Leverett',
+// 		locality: 'Leverett',
+// 		state: 'Massachusetts',
+// 		type: 'Locality',
+// 	},
+// 	{
+// 		county: 'Levy',
+// 		display_name: 'Levy',
+// 		locality: null,
+// 		state: 'Florida',
+// 		type: 'County',
+// 	},
+// 	{
+// 		county: 'Marion',
+// 		display_name: 'Belleview',
+// 		locality: 'Belleview',
+// 		state: 'Florida',
+// 		type: 'Locality',
+// 	},
+// ];
+
+// Setup function to mount the component with optional props
+const mountComponent = (props = { id: '' }) => {
+	return mount(TypeaheadInput, {
+		props: {
+			items: MOCK_ITEMS,
+			...props,
+		},
+		attachTo: document.body,
+	});
+};
+
+// Function to get the input element
+const getInput = (wrapper) => wrapper.find('[data-test="typeahead-input"]');
+
+// Function to get the list items
+const getListItems = (wrapper) =>
+	wrapper.findAll('[data-test="typeahead-list-item"]');
+
+// Function to set input value and wait for update
+const setInputValue = async (input, value) => {
+	input.setValue(value);
+	await nextTick();
+};
+
+// Function to focus input and set value
+const focusAndSetInput = async (wrapper, value) => {
+	const input = getInput(wrapper);
+	await input.trigger('focus');
+	await setInputValue(input, value);
+};
+
+// Test suite
+describe('TypeaheadInput', () => {
+	it('emits onInput event', async () => {
+		const wrapper = mountComponent();
+		const input = getInput(wrapper);
+
+		await input.trigger('input');
+
+		expect(wrapper.html()).toMatchSnapshot();
+		expect(wrapper.emitted().onInput).toBeTruthy();
+	});
+
+	it('emits onFocus event and clears input if no items', async () => {
+		const wrapper = mountComponent();
+		const input = getInput(wrapper);
+		await setInputValue(input, MOCK_SEARCH_VALUE);
+
+		wrapper.setProps({ items: [] });
+		await input.trigger('click');
+		await input.trigger('focus');
+
+		await nextTick();
+
+		expect(wrapper.html()).toMatchSnapshot();
+		expect(wrapper.emitted().onFocus).toBeTruthy();
+		expect(input.text()).toBe('');
+	});
+
+	it('emits onBlur event', async () => {
+		const wrapper = mountComponent();
+		const input = getInput(wrapper);
+
+		await input.trigger('blur');
+
+		expect(wrapper.html()).toMatchSnapshot();
+		expect(wrapper.emitted().onBlur).toBeTruthy();
+	});
+
+	it('focuses next list item on arrow down', async () => {
+		const wrapper = mountComponent();
+		await focusAndSetInput(wrapper, MOCK_SEARCH_VALUE);
+		const [item1, item2] = getListItems(wrapper);
+
+		await getInput(wrapper).trigger('click');
+		await getInput(wrapper).trigger('keydown', {
+			key: 'ArrowDown',
+			keyCode: 40,
+		});
+
+		expect(document.activeElement).toBe(item1.element);
+
+		await item1.trigger('keydown', { key: 'ArrowDown', keyCode: 40 });
+
+		expect(document.activeElement).toBe(item2.element);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('focuses previous list item on arrow up', async () => {
+		const wrapper = mountComponent();
+		await focusAndSetInput(wrapper, MOCK_SEARCH_VALUE);
+		const [item1, item2] = getListItems(wrapper);
+
+		await item2.trigger('focus');
+		await item2.trigger('keydown', { key: 'ArrowUp', keyCode: 38 });
+
+		expect((document.activeElement as HTMLElement).innerText).toContain(
+			item1.element.textContent
+		);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('focuses input on arrow up from first list item', async () => {
+		const wrapper = mountComponent();
+		await focusAndSetInput(wrapper, MOCK_SEARCH_VALUE);
+		const [item1] = getListItems(wrapper);
+
+		await item1.trigger('focus');
+		await item1.trigger('keydown', { key: 'ArrowUp', keyCode: 38 });
+
+		expect(document.activeElement).toBe(getInput(wrapper).element);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('selects item and emits selectItem event on click', async () => {
+		const wrapper = mountComponent();
+		await focusAndSetInput(wrapper, MOCK_SEARCH_VALUE);
+		const item1 = getListItems(wrapper)[0];
+
+		await item1.trigger('click');
+		expect(wrapper.emitted().selectItem).toBeTruthy();
+		// @ts-expect-error
+		expect(wrapper.emitted().selectItem[0][0]).toEqual(MOCK_ITEMS[0]);
+	});
+
+	it('selects item and emits selectItem event on enter', async () => {
+		const wrapper = mountComponent();
+		await focusAndSetInput(wrapper, MOCK_SEARCH_VALUE);
+		const item1 = getListItems(wrapper)[0];
+
+		await item1.trigger('keydown', { key: 'Enter', keyCode: 13 });
+		expect(wrapper.emitted().selectItem).toBeTruthy();
+		// @ts-expect-error
+		expect(wrapper.emitted().selectItem[0][0]).toEqual(MOCK_ITEMS[0]);
+	});
+
+	// TODO: set up test as above for complex items
+	// it('formats text correctly for different item types', () => {
+	// 	const { vm } = mountComponent();
+
+	// 	const localityItem = {
+	// 		display_name: 'City',
+	// 		county: 'County',
+	// 		state: 'California',
+	// 		type: 'Locality',
+	// 	};
+	// 	const countyItem = {
+	// 		display_name: 'County',
+	// 		state: 'California',
+	// 		type: 'County',
+	// 	};
+	// 	const stateItem = { display_name: 'California', type: 'State' };
+
+	// 	expect(vm.formatText(localityItem)).toBe('City County CA');
+	// 	expect(vm.formatText(countyItem)).toBe('County CA');
+	// 	expect(vm.formatText(stateItem)).toBe('California');
+	// });
+
+	it('bolds matched text correctly', () => {
+		const { vm } = mountComponent();
+		// @ts-expect-error
+		vm.input = 'test';
+
+		// @ts-expect-error
+		expect(vm.boldMatchText('This is a test string')).toBe(
+			'This is a <strong>test</strong> string'
+		);
+	});
+
+	it('computes wrapperId correctly', () => {
+		const { vm } = mountComponent({
+			id: 'test-id',
+		});
+
+		// @ts-expect-error
+		expect(vm.wrapperId).toBe('test-id_wrapper');
+	});
+
+	it('computes itemsToDisplay correctly', () => {
+		const { vm } = mountComponent();
+
+		// @ts-expect-error
+		expect(vm.itemsToDisplay).toEqual(MOCK_ITEMS);
+	});
+});

--- a/src/components/AsyncTypeahead/types.ts
+++ b/src/components/AsyncTypeahead/types.ts
@@ -1,7 +1,7 @@
 export interface PdapAsyncTypeaheadProps<T> {
 	id: string;
 	placeholder?: string;
-	items?: T[];
+	items: T[] | undefined;
 	formatItemForDisplay?: (item: T) => string;
 	error?: string;
 }

--- a/src/components/AsyncTypeahead/types.ts
+++ b/src/components/AsyncTypeahead/types.ts
@@ -1,0 +1,7 @@
+export interface PdapAsyncTypeaheadProps<T> {
+	id: string;
+	placeholder?: string;
+	items?: T[];
+	formatItemForDisplay?: (item: T) => string;
+	error?: string;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,3 +20,4 @@ export { Dropdown } from './Dropdown';
 export { Breadcrumbs } from './Breadcrumbs';
 export { Spinner } from './Spinner';
 export { RecordTypeIcon } from './RecordTypeIcon';
+export { AsyncTypeahead } from './AsyncTypeahead';

--- a/src/demo/pages/TypeaheadDemo.vue
+++ b/src/demo/pages/TypeaheadDemo.vue
@@ -1,0 +1,116 @@
+<template>
+	<main>
+		<h1>Typeahead test</h1>
+
+		<AsyncTypeahead
+			id="typeahead"
+			ref="typeaheadRef"
+			class="md:col-span-2"
+			:error="typeaheadError"
+			:format-item-for-display="getFullText"
+			:items="items"
+			placeholder="Search for a person"
+			@select-item="
+				(item) => {
+					if (item) {
+						selectedItems = [...selectedItems, item];
+						items = [];
+					}
+				}
+			"
+			@on-input="fetchTypeaheadResults"
+		>
+			<!-- Item to render passed as scoped slot -->
+			<template #item="item">
+				<span v-html="typeaheadRef?.boldMatchText(getFullText(item))" />
+				<span class="select">Select</span>
+			</template>
+			<template #not-found>
+				<span>
+					We don't have agencies in the place you're looking for. Is it spelled
+					correctly? If our database is missing something, please reach us at
+					<a href="mailto:contact@pdap.io">contact@pdap.io</a>
+				</span>
+			</template>
+		</AsyncTypeahead>
+	</main>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { AsyncTypeahead } from '../../components/AsyncTypeahead';
+
+const stuff = [
+	{
+		name: 'John',
+		age: 20,
+		occupation: 'Developer',
+	},
+	{
+		name: 'Joshua',
+		age: 30,
+		occupation: 'Developer',
+	},
+	{
+		name: 'Sarah',
+		age: 28,
+		occupation: 'Designer',
+	},
+	{
+		name: 'Michael',
+		age: 35,
+		occupation: 'Manager',
+	},
+	{
+		name: 'Emily',
+		age: 25,
+		occupation: 'Engineer',
+	},
+	{
+		name: 'David',
+		age: 32,
+		occupation: 'Architect',
+	},
+	{
+		name: 'Jessica',
+		age: 29,
+		occupation: 'Analyst',
+	},
+	{
+		name: 'Robert',
+		age: 41,
+		occupation: 'Director',
+	},
+	{
+		name: 'Lisa',
+		age: 27,
+		occupation: 'Developer',
+	},
+	{
+		name: 'James',
+		age: 33,
+		occupation: 'Designer',
+	},
+];
+
+const typeaheadRef = ref();
+const items = ref<typeof stuff | undefined>([]);
+const selectedItems = ref<typeof stuff>([]);
+const typeaheadError = ref();
+
+function getFullText(item: (typeof stuff)[number]) {
+	return `${item.name} (${item.age}), ${item.occupation}`;
+}
+
+const fetchTypeaheadResults = async (e: InputEvent) => {
+	const val = (e.target as HTMLInputElement)?.value;
+	if (typeof val === 'string' && val.length > 1) {
+		items.value =
+			stuff.filter((item) =>
+				item.name.toLowerCase().includes(val.toLowerCase())
+			) ?? undefined;
+	} else {
+		items.value = [];
+	}
+};
+</script>

--- a/src/demo/pages/TypeaheadDemo.vue
+++ b/src/demo/pages/TypeaheadDemo.vue
@@ -27,7 +27,7 @@
 			</template>
 			<template #not-found>
 				<span>
-					We don't have agencies in the place you're looking for. Is it spelled
+					We can't find the person you're looking for. Is their name spelled
 					correctly? If our database is missing something, please reach us at
 					<a href="mailto:contact@pdap.io">contact@pdap.io</a>
 				</span>

--- a/src/demo/router.js
+++ b/src/demo/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import ComponentDemo from './pages/ComponentDemo.vue';
 import SignupFormDemo from './pages/SignupFormDemo.vue';
+import TypeaheadDemo from './pages/TypeaheadDemo.vue';
 import FormV2Demo from './pages/FormV2Demo.vue';
 
 const routes = [
@@ -50,6 +51,11 @@ const routes = [
 	{
 		path: '/form-v2-demo',
 		component: FormV2Demo,
+		name: 'FormV2 Demo',
+	},
+	{
+		path: '/typeahead-demo',
+		component: TypeaheadDemo,
 		name: 'FormV2 Demo',
 	},
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './components';
 import './styles/styles.css';
 
 // Types
+export * from './components/AsyncTypeahead/types';
 export * from './components/Button/types';
 export * from './components/Dropdown/types';
 export * from './components/ErrorBoundary/types';


### PR DESCRIPTION
adds typeahead and associated tests

resolves #133

<!-- Title of PR should use a standard commit prefix (feat, fix, chore, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. feat(components): add MyFancyComponent -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->
# `AsyncTypeahead` component

<!-- What is the rationale for the changes? -->
## Background
- this component was originally built in `pdap.io`. Now we need it to be shared, so we're adding to the component library.

<!-- What is the description of the changes? -->
## Description
- Adds async typeahead dropdown and associated tests.

## Acceptance Criteria
<!-- What are the steps to test the changes? -->
1. Run demo app, navigate to `/typeahead-demo`, and ensure that it works. (Search "Jo" to see multiple items.)