### PR TITLE
fix: update mobile spacing and focus states

### DIFF
--- a/src/components/AsyncTypeahead/AsyncTypeahead.vue
+++ b/src/components/AsyncTypeahead/AsyncTypeahead.vue
@@ -229,12 +229,12 @@ defineExpose({
 }
 
 .pdap-typeahead-input {
-	@apply rounded-md;
+	@apply rounded-sm;
 }
 
 .pdap-typeahead-input,
 .pdap-typeahead-list {
-	@apply bg-neutral-50 border-2 border-neutral-500 border-solid p-2 text-neutral-950;
+	@apply bg-neutral-50 border-2 border-brand-gold-300 border-solid p-2 text-neutral-950;
 }
 
 .pdap-typeahead-input::placeholder {
@@ -244,7 +244,7 @@ defineExpose({
 .pdap-typeahead-input:focus,
 .pdap-typeahead-input:focus-within,
 .pdap-typeahead-input:focus-visible {
-	@apply border-2 border-brand-gold border-solid outline-none;
+	@apply border-2 border-brand-gold-300 border-solid outline-none;
 }
 
 .pdap-typeahead-list {

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -1,6 +1,6 @@
 <template>
 	<footer
-		class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 lg:p-2 lg:px-8 relative lg:sticky lg:bottom-0 text-med xl:text-xl"
+		class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 md:p-3 relative lg:sticky lg:bottom-0 text-med xl:text-xl"
 	>
 		<!-- LINKS -->
 		<ul
@@ -73,6 +73,7 @@ import {
 	faInbox,
 	faBook,
 	faEnvelope,
+	faArrowsToDot,
 } from '@fortawesome/free-solid-svg-icons';
 
 const iconMap = new Map<FooterIconName, IconDefinition>([
@@ -82,6 +83,7 @@ const iconMap = new Map<FooterIconName, IconDefinition>([
 	[FOOTER_LINK_ICONS.JOBS, faSmile],
 	[FOOTER_LINK_ICONS.NEWSLETTER, faInbox],
 	[FOOTER_LINK_ICONS.DOCS, faBook],
+	[FOOTER_LINK_ICONS.PUBLISH, faArrowsToDot],
 ]);
 
 const links = inject<PdapFooterSocialLinks[]>('footerLinks', [

--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Footer component > Renders a footer 1`] = `
-<footer class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 lg:p-2 lg:px-8 relative lg:sticky lg:bottom-0 text-med xl:text-xl">
+<footer class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 md:p-3 relative lg:sticky lg:bottom-0 text-med xl:text-xl">
   <!-- LINKS -->
   <ul class="grid grid-cols-2 gap-2 md:grid-cols-[auto_auto_auto] lg:w-max lg:gap-x-3 xl:gap-x-4">
     <li class="w-max">

--- a/src/components/Footer/constants.ts
+++ b/src/components/Footer/constants.ts
@@ -8,4 +8,5 @@ export const FOOTER_LINK_ICONS = {
 	NEWSLETTER: 'newsletter',
 	DOCS: 'docs',
 	EMAIL: 'email',
+	PUBLISH: 'publish',
 } as const;

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -69,12 +69,12 @@ export default {
 
 <style>
 .pdap-header {
-	@apply dark:bg-brand-wine-800 relative bg-neutral-50 flex justify-between p-4 md:p-4 w-full z-50;
+	@apply dark:bg-brand-wine-800 relative bg-neutral-50 flex justify-between p-2 md:p-3  w-full z-50;
 }
 
 .logo {
-	@apply decoration-0 relative max-w-[80%] text-xl font-bold px-2 py-1;
-	@apply outline outline-wineneutral-500 text-brand-wine-400 dark:outline-wineneutral-500 dark:text-brand-wine-50;
+	@apply decoration-0 relative max-w-[80%] text-xl font-bold px-3 py-1.5;
+	@apply border-2 border-wineneutral-500 text-brand-wine-400 dark:border-wineneutral-500 dark:text-brand-wine-50;
 	@apply lg:text-lg;
 	@apply xs:max-w-none;
 }

--- a/src/components/Input/PdapInput.vue
+++ b/src/components/Input/PdapInput.vue
@@ -56,7 +56,7 @@ const errorMessageId = computed(() => `pdap-${props.name}-input-error`);
 }
 
 .pdap-input input {
-	@apply dark:bg-neutral-950 border border-neutral-500 border-solid px-3 py-2 text-[rgba(0,0,0)];
+	@apply dark:bg-neutral-950 border border-goldneutral-500 border-solid px-3 py-2 text-[rgba(0,0,0)];
 }
 
 .pdap-input input::placeholder {
@@ -102,7 +102,7 @@ const errorMessageId = computed(() => `pdap-${props.name}-input-error`);
 }
 
 .pdap-input-checkbox-checked {
-	@apply border-2 border-brand-gold border-solid rounded-md;
+	@apply border-2 border-brand-gold border-solid rounded-sm;
 }
 
 .pdap-input input[type='checkbox'] {

--- a/src/components/InputDatePicker/PdapInputDatePicker.vue
+++ b/src/components/InputDatePicker/PdapInputDatePicker.vue
@@ -141,6 +141,6 @@ div[role='gridcell'] {
 div[role='gridcell']:hover,
 div[role='gridcell']:focus,
 div[role='gridcell']:focus-visible {
-	@apply border-2 border-brand-gold-500 border-solid outline-none;
+	@apply border-2 border-brand-gold-300 border-solid outline-none;
 }
 </style>

--- a/src/components/InputSelect/PdapInputSelect.vue
+++ b/src/components/InputSelect/PdapInputSelect.vue
@@ -322,11 +322,11 @@ watch(
 
 @layer components {
 	.pdap-custom-select {
-		@apply relative w-full bg-neutral-50 border-2 border-solid border-neutral-500 cursor-pointer text-lg rounded-md;
+		@apply relative w-full bg-neutral-50 border-2 border-solid border-goldneutral-500 cursor-pointer text-lg rounded-sm;
 	}
 
 	.pdap-custom-select-options {
-		@apply absolute top-[115%] left-[-2px] w-[calc(100%+4px)] bg-neutral-50 border-solid border border-neutral-500 max-h-48 overflow-y-auto z-20 p-1;
+		@apply absolute top-[115%] left-[-2px] w-[calc(100%+4px)] bg-neutral-50 border-solid border border-goldneutral-500 max-h-48 overflow-y-auto z-20 p-1;
 	}
 
 	.pdap-custom-select-option {
@@ -336,12 +336,12 @@ watch(
 	.pdap-custom-select:focus,
 	.pdap-custom-select-option:hover,
 	.pdap-custom-select-option:focus {
-		@apply border-2 border-brand-gold-500 border-solid outline-none;
+		@apply border-2 border-brand-gold-300 border-solid outline-none;
 	}
 
 	.pdap-custom-select-option:hover,
 	.pdap-custom-select-option:focus {
-		@apply bg-neutral-200;
+		@apply bg-goldneutral-200;
 	}
 
 	.pdap-custom-select input {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -20,7 +20,7 @@
 	}
 
 	main {
-		@apply p-8;
+		@apply p-2 md:p-4 lg:p-8;
 	}
 
 	/* Images */
@@ -145,13 +145,13 @@
 		@apply border-2 border-transparent border-solid outline-none;
 	}
 
-a:focus:not(.pdap-nav-link),
-a:focus-visible:not(.pdap-nav-link),
+a:focus,
+a:focus-visible,
 button:focus,
 button:focus-visible,
 [role="button"]:focus,
 [role="button"]:focus-visible {
-		@apply border-2 border-brand-gold-500 border-solid outline-none;
+		@apply border-2 border-brand-gold-300 border-solid outline-none;
 	}
 
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -47,7 +47,7 @@
 
 	.pdap-input input,
 	.pdap-input textarea {
-		@apply bg-neutral-50 border-neutral-500 border-solid border-2 px-3 py-2 text-neutral-950 text-lg rounded-md;
+		@apply bg-neutral-50 border-goldneutral-500 border-solid border-2 px-3 py-2 text-neutral-950 text-lg rounded-sm;
 	}
 
 	.pdap-input input::placeholder,
@@ -62,7 +62,7 @@
 	.pdap-input textarea:focus-within,
 	.pdap-input textarea:focus-visible, 
 	.pdap-input-checkbox:has(input[type="checkbox"]:focus) {
-		@apply border-2 border-brand-gold-500 border-solid outline-none;
+		@apply border-2 border-brand-gold-300 border-solid outline-none;
 	}
 
 	.pdap-input label {
@@ -92,14 +92,14 @@
 	/* Input - checkbox and radio */
 	.pdap-input-checkbox,
 	.pdap-input-radio {
-		@apply border-2 border-transparent items-center py-1 px-2 w-auto rounded-md;
+		@apply border-2 border-transparent items-center py-1 px-2 w-auto rounded-sm;
 	}
 
 	.pdap-input-checkbox:has(input:checked),
 	.pdap-input-radio:has(input:checked),
 	.pdap-input-checkbox:has(input:checked):has(input[type="checkbox"]:focus),
 	.pdap-input-radio:has(input:checked):has(input[type="checkbox"]:focus) {
-		@apply border-2 border-brand-gold border-solid rounded-md;
+		@apply border-2 border-brand-gold-300 border-solid rounded-sm;
 	}
 
 	.pdap-input input[type='checkbox'], 
@@ -117,7 +117,7 @@
 
 	.pdap-input input[type='checkbox'] ~ label::before,
 	.pdap-input input[type='radio'] ~ label::before {
-		@apply block border-2 border-solid border-neutral-800 h-6 w-6 content-['']; 
+		@apply block border-2 border-solid border-goldneutral-800 h-6 w-6 content-['']; 
 	}
 
 	.pdap-input input[type='checkbox'] ~ label::before {


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. feat(components): add MyFancyComponent -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->
# mobile spacing and focus states

<!-- What is the rationale for the changes? -->
## Background
- fixes https://github.com/Police-Data-Accessibility-Project/design-system/issues/123

<!-- What is the description of the changes? -->
## Description
- shrinks padding on `main`
- adjusts many `neutral` borders (checkboxes, focus states) to `goldneutral`
- tightens padding on search
- adds footer icon for `PUBLISH`