### PR TITLE
Fix nav links

### DIFF
--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -67,7 +67,7 @@ exports[`Footer component > Renders a footer 1`] = `
     <span class="inline-block bg-neutral-50 dark:bg-neutral-950 h-3 w-full rounded-full relative before:inline-block before:h-full before:bg-brand-gold before:absolute before:rounded-l-full before:transition-[width] before:duration-1000 before:ease-out before:w-[var(--fundraising-progress)]"></span>
   </div><!-- COPYRIGHT AND TRANSPARENCY -->
   <div class="flex gap-4 justify-between lg:justify-start lg:ml-auto">
-    <p class="lg:max-w-[325px] lg:text-right xl:max-w-[375px]"> © 2024 Police Data Accessibility Project is a non-profit. EIN: 85-4207132. </p><!-- Widget / logo links -->
+    <p class="lg:max-w-[325px] lg:text-right xl:max-w-[375px]"> © 2025 Police Data Accessibility Project is a non-profit. EIN: 85-4207132. </p><!-- Widget / logo links -->
     <a href="https://www.guidestar.org/profile/85-4207132" rel="noreferrer" target="_blank">
       <img alt="platinum transparency" class="w-14 h-14" src="https://widgets.guidestar.org/gximage2?o=9973356&amp;l=v4">
     </a>

--- a/src/components/Header/PdapHeader.vue
+++ b/src/components/Header/PdapHeader.vue
@@ -75,7 +75,7 @@ export default {
 
 <style>
 .pdap-header {
-	@apply dark:bg-neutral-300 relative bg-neutral-50 flex justify-between p-4 md:p-6 w-full z-50;
+	@apply dark:bg-brand-wine-800 relative bg-neutral-50 flex flex-row items-center justify-between p-2 md:p-3  w-full z-50;
 }
 
 .logo {

--- a/src/components/Nav/PdapNav.vue
+++ b/src/components/Nav/PdapNav.vue
@@ -182,20 +182,20 @@ export default {
 	}
 
 	.pdap-nav-link-container {
-		@apply align-top basis-[max-content] p-2 lg:p-0 inline-block list-none relative m-0;
+		@apply flex align-top basis-[max-content] p-2 lg:p-0 inline-block list-none relative m-0;
 		@apply lg:flex-shrink-0 lg:flex-grow;
 	}
 
 	.pdap-nav-link {
-		@apply decoration-0 font-medium p-2 text-left text-xl lg:text-lg text-neutral-950;
+		@apply decoration-0 font-medium py-1.5 px-3 text-left text-xl lg:text-lg text-wineneutral-950;
 	}
 
 	.pdap-nav-link-current {
-		@apply lg:outline-neutral-800 lg:outline text-neutral-950;
+		@apply lg:border-wineneutral-800 text-neutral-950;
 	}
 
 	.pdap-nav-link-current-exact {
-		@apply pdap-nav-link-current lg:outline-neutral-800;
+		@apply pdap-nav-link-current lg:border-wineneutral-800;
 	}
 
 	.pdap-nav-open-button {


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. feat(components): add MyFancyComponent -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->
# Fix nav link appearance

- I did not actually resolve #131; this does it by making the border for focus and current take up the same space, with `focus` still sitting on top. It also tweaks the header so that the links and the name line up vertically!

<img width="498" alt="Screen Shot 2025-01-30 at 6 33 49 PM" src="https://github.com/user-attachments/assets/85ec48b9-967f-427f-aabf-5d9e818043d7" />
