### PR TITLE
Fix: footer to z-1000

### DIFF
--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -1,6 +1,6 @@
 <template>
 	<footer
-		class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 md:p-3 relative lg:sticky lg:bottom-0 text-med xl:text-xl"
+		class="z-1000 bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 md:p-3 relative lg:sticky lg:bottom-0 text-med xl:text-xl"
 	>
 		<!-- LINKS -->
 		<ul

--- a/src/components/Footer/__snapshots__/footer.spec.ts.snap
+++ b/src/components/Footer/__snapshots__/footer.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Footer component > Renders a footer 1`] = `
-<footer class="bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 md:p-3 relative lg:sticky lg:bottom-0 text-med xl:text-xl">
+<footer class="z-1000 bg-brand-wine text-wineneutral-50 dark:text-wineneutral-950 flex flex-col justify-center lg:flex-row gap-4 xl:gap-12 p-2 md:p-3 relative lg:sticky lg:bottom-0 text-med xl:text-xl">
   <!-- LINKS -->
   <ul class="grid grid-cols-2 gap-2 md:grid-cols-[auto_auto_auto] lg:w-max lg:gap-x-3 xl:gap-x-4">
     <li class="w-max">


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. feat(components): add MyFancyComponent -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->
# Footer wins!

<!-- What is the rationale for the changes? -->
## Background
The map spinner, at z-50, loads ahead of this 
<!-- What is the description of the changes? -->