### PR TITLE
fix(button): prevent hover brightness change on disabled buttons

### DIFF
--- a/src/components/Button/PdapButton.vue
+++ b/src/components/Button/PdapButton.vue
@@ -48,7 +48,7 @@ export default {
 @layer components {
 	.pdap-button {
 		@apply cursor-pointer border-2 border-brand-gold decoration-0 disabled:opacity-50 font-semibold inline-block px-6 py-2 rounded-none text-center text-lg w-full;
-		@apply hover:brightness-85 lg:text-xl sm:max-w-max;
+		@apply enabled:hover:brightness-85 lg:text-xl sm:max-w-max;
 	}
 
 	.pdap-button-primary {

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -289,3 +289,4 @@ export default {
 	}
 }
 </style>
+

--- a/src/components/Footer/PdapFooter.vue
+++ b/src/components/Footer/PdapFooter.vue
@@ -289,4 +289,3 @@ export default {
 	}
 }
 </style>
-

--- a/src/demo/pages/ComponentDemo.vue
+++ b/src/demo/pages/ComponentDemo.vue
@@ -107,6 +107,18 @@
 					clickable pills in current data sources search results)
 				</p>
 			</div>
+			<div>
+				<h3>Button primary (disabled)</h3>
+				<Button disabled>Primary button</Button>
+			</div>
+			<div>
+				<h3>Button secondary (disabled)</h3>
+				<Button intent="secondary" disabled>Secondary button</Button>
+			</div>
+			<div>
+				<h3>Button tertiary (disabled)</h3>
+				<Button intent="tertiary" disabled>Tertiary button</Button>
+			</div>
 		</div>
 
 		<h2>Dropdown: click or press to open</h2>


### PR DESCRIPTION
Scope hover:brightness-85 to enabled:hover so disabled buttons no longer visually respond to hover interactions. Also adds disabled variants for all three button intents to the component demo.

# Fix disabled button hovering style

Discovered while working on https://github.com/Police-Data-Accessibility-Project/pdap.io/issues/405 and realized this was a design system issue and should be fixed upstream. If I should create an issue to represent this, please let me know.

Also, I added disabled buttons to the component demo. (Note, in previous design systems I've worked on, we used [Storybook](https://storybook.js.org/) to demo components to stakeholders; pretty cool alternative to the bespoke component demo page)

## Background

N/A

## Description

Scope hover:brightness-85 to enabled:hover so disabled buttons no longer visually respond to hover interactions. Also adds disabled variants for all three button intents to the component demo.

## Acceptance Criteria

1. Validate that disabled buttons no longer change on hover. 